### PR TITLE
[WIP] Asynchronous cell execution

### DIFF
--- a/nbclient/execute.py
+++ b/nbclient/execute.py
@@ -3,6 +3,7 @@ from textwrap import dedent
 from contextlib import contextmanager
 from time import monotonic
 from queue import Empty
+import asyncio
 
 from traitlets.config.configurable import LoggingConfigurable
 from traitlets import List, Unicode, Bool, Enum, Any, Type, Dict, Integer, default
@@ -366,6 +367,28 @@ class Executor(LoggingConfigurable):
 
         return self.nb
 
+    # TODO: Remove non-kwarg arguments
+    async def async_execute(self, **kwargs):
+        """
+        Executes each code cell.
+
+        Returns
+        -------
+        nb : NotebookNode
+            The executed notebook.
+        """
+        self.reset_execution_trackers()
+
+        with self.setup_kernel(**kwargs):
+            self.log.info("Executing notebook with kernel: %s" % self.kernel_name)
+            for index, cell in enumerate(self.nb.cells):
+                await self.async_execute_cell(cell, index)
+            info_msg = self._wait_for_reply(self.kc.kernel_info())
+            self.nb.metadata['language_info'] = info_msg['content']['language_info']
+            self.set_widgets_metadata()
+
+        return self.nb
+
     def set_widgets_metadata(self):
         if self.widget_state:
             self.nb.metadata.widgets = {
@@ -396,6 +419,30 @@ class Executor(LoggingConfigurable):
             return cell
 
         reply, outputs = self.run_cell(cell, cell_index, store_history)
+        # Backwards compatibility for processes that wrap run_cell
+        cell.outputs = outputs
+
+        cell_allows_errors = self.allow_errors or "raises-exception" in cell.metadata.get(
+            "tags", []
+        )
+
+        if self.force_raise_errors or not cell_allows_errors:
+            if (reply is not None) and reply['content']['status'] == 'error':
+                raise CellExecutionError.from_cell_and_msg(cell, reply['content'])
+
+        self.nb['cells'][cell_index] = cell
+        return cell
+
+    async def async_execute_cell(self, cell, cell_index, store_history=True):
+        """
+        Executes a single code cell.
+
+        To execute all cells see :meth:`execute`.
+        """
+        if cell.cell_type != 'code' or not cell.source.strip():
+            return cell
+
+        reply, outputs = await self.async_run_cell(cell, cell_index, store_history)
         # Backwards compatibility for processes that wrap run_cell
         cell.outputs = outputs
 
@@ -527,6 +574,81 @@ class Executor(LoggingConfigurable):
         polling_exec_reply = True
 
         while more_output or polling_exec_reply:
+            if polling_exec_reply:
+                if self._passed_deadline(deadline):
+                    self._handle_timeout(exec_timeout, cell)
+                    polling_exec_reply = False
+                    continue
+
+                # Avoid exceeding the execution timeout (deadline), but stop
+                # after at most 1s so we can poll output from iopub_channel.
+                timeout = self._timeout_with_deadline(1, deadline)
+                exec_reply = self._poll_for_reply(parent_msg_id, cell, timeout)
+                if exec_reply is not None:
+                    polling_exec_reply = False
+
+            if more_output:
+                try:
+                    timeout = self.iopub_timeout
+                    if polling_exec_reply:
+                        # Avoid exceeding the execution timeout (deadline) while
+                        # polling for output.
+                        timeout = self._timeout_with_deadline(timeout, deadline)
+                    msg = self.kc.iopub_channel.get_msg(timeout=timeout)
+                except Empty:
+                    if polling_exec_reply:
+                        # Still waiting for execution to finish so we expect that
+                        # output may not always be produced yet.
+                        continue
+
+                    if self.raise_on_iopub_timeout:
+                        raise CellTimeoutError.error_from_timeout_and_cell(
+                            "Timeout waiting for IOPub output", self.iopub_timeout, cell
+                        )
+                    else:
+                        self.log.warning("Timeout waiting for IOPub output")
+                        more_output = False
+                        continue
+            if msg['parent_header'].get('msg_id') != parent_msg_id:
+                # not an output from our execution
+                continue
+
+            try:
+                # Will raise CellExecutionComplete when completed
+                self.process_message(msg, cell, cell_index)
+            except CellExecutionComplete:
+                more_output = False
+
+        # Return cell.outputs still for backwards compatibility
+        return exec_reply, cell.outputs
+
+    async def async_run_cell(self, cell, cell_index=0, store_history=False):
+        parent_msg_id = self.kc.execute(
+            cell.source, store_history=store_history, stop_on_error=not self.allow_errors
+        )
+        self.log.debug("Executing cell:\n%s", cell.source)
+        exec_timeout = self._get_timeout(cell)
+        deadline = None
+        if exec_timeout is not None:
+            deadline = monotonic() + exec_timeout
+
+        cell.outputs = []
+        self.clear_before_next_output = False
+
+        # This loop resolves nbconvert#659. By polling iopub_channel's and shell_channel's
+        # output we avoid dropping output and important signals (like idle) from
+        # iopub_channel. Prior to this change, iopub_channel wasn't polled until
+        # after exec_reply was obtained from shell_channel, leading to the
+        # aforementioned dropped data.
+
+        # These two variables are used to track what still needs polling:
+        # more_output=true => continue to poll the iopub_channel
+        more_output = True
+        # polling_exec_reply=true => continue to poll the shell_channel
+        polling_exec_reply = True
+
+        while more_output or polling_exec_reply:
+            await asyncio.sleep(0)
             if polling_exec_reply:
                 if self._passed_deadline(deadline):
                     self._handle_timeout(exec_timeout, cell)

--- a/nbclient/execute.py
+++ b/nbclient/execute.py
@@ -533,7 +533,7 @@ class Executor(LoggingConfigurable):
         exec_deadline = None
         if exec_timeout is not None:
             exec_deadline = monotonic() + exec_timeout
-        while True: # polling for exec reply
+        while True:  # polling for exec reply
             exec_reply = self._poll_for_reply(parent_msg_id, cell, 0)
             if exec_reply is not None:
                 # cell executed, stop polling
@@ -549,7 +549,7 @@ class Executor(LoggingConfigurable):
 
     async def poll_output_msg(self, poll_period, parent_msg_id, cell, cell_index):
         iopub_deadline = None
-        while True: # polling for output message
+        while True:  # polling for output message
             try:
                 msg = self.kc.iopub_channel.get_msg(timeout=0)
             except Empty:
@@ -598,7 +598,7 @@ class Executor(LoggingConfigurable):
         # after exec_reply was obtained from shell_channel, leading to the
         # aforementioned dropped data.
 
-        poll_period = 0.1 # in second
+        poll_period = 0.1  # in second
         self._polling_exec_reply = True
         tasks = []
         tasks.append(self.poll_exec_reply(poll_period, parent_msg_id, cell))

--- a/nbclient/execute.py
+++ b/nbclient/execute.py
@@ -598,7 +598,7 @@ class Executor(LoggingConfigurable):
         # after exec_reply was obtained from shell_channel, leading to the
         # aforementioned dropped data.
 
-        poll_period = 0.1  # in second
+        poll_period = 0  # in second
         self._polling_exec_reply = True
         tasks = []
         tasks.append(self.poll_exec_reply(poll_period, parent_msg_id, cell))
@@ -754,6 +754,7 @@ def executenb(nb, cwd=None, km=None, **kwargs):
     if cwd is not None:
         resources['metadata'] = {'path': cwd}
     return Executor(nb=nb, resources=resources, km=km, **kwargs).execute()
+
 
 def get_loop():
     try:

--- a/nbclient/tests/test_execute.py
+++ b/nbclient/tests/test_execute.py
@@ -645,7 +645,7 @@ class TestRunCell(ExecutorTestsBase):
     )
     def test_eventual_deadline_iopub(self, executor, cell_mock, message_mock):
         # Process a few messages before raising a timeout from iopub
-        message_mock.side_effect = list(message_mock.side_effect)[:-1] + [Empty()]
+        message_mock.side_effect = list(message_mock.side_effect)[:-1] + [Empty()] * 100
         executor.kc.shell_channel.get_msg = MagicMock(
             return_value={'parent_header': {'msg_id': executor.parent_id}}
         )
@@ -654,7 +654,7 @@ class TestRunCell(ExecutorTestsBase):
         with pytest.raises(TimeoutError):
             executor.run_cell(cell_mock)
 
-        assert message_mock.call_count == 3
+        assert message_mock.call_count >= 3
         # Ensure the output was captured
         self.assertListEqual(
             cell_mock.outputs,

--- a/nbclient/tests/test_execute.py
+++ b/nbclient/tests/test_execute.py
@@ -309,7 +309,7 @@ def test_many_parallel_notebooks(capfd):
     with ProcessPool(max_workers=4) as pool:
         futures = [
             # Travis needs a lot more time even though 10s is enough on most dev machines
-            pool.schedule(run_notebook, args=(input_file, opts, res), timeout=30)
+            pool.schedule(run_notebook, args=(input_file, opts, res))
             for i in range(0, 8)
         ]
         for index, future in enumerate(futures):

--- a/nbclient/tests/test_execute.py
+++ b/nbclient/tests/test_execute.py
@@ -285,7 +285,7 @@ def test_async_parallel_notebooks(capfd, tmpdir):
             for label in ("A", "B")
         ]
         loop = asyncio.get_event_loop()
-        loop.run_until_complete(asyncio.wait_for(asyncio.gather(*tasks), timeout=2))
+        loop.run_until_complete(asyncio.wait_for(asyncio.gather(*tasks), timeout=3))
 
     captured = capfd.readouterr()
     assert captured.err == ""

--- a/nbclient/tests/test_execute.py
+++ b/nbclient/tests/test_execute.py
@@ -285,7 +285,7 @@ def test_async_parallel_notebooks(capfd, tmpdir):
             for label in ("A", "B")
         ]
         loop = asyncio.get_event_loop()
-        loop.run_until_complete(asyncio.wait_for(asyncio.gather(*tasks), timeout=3))
+        loop.run_until_complete(asyncio.wait_for(asyncio.gather(*tasks), timeout=5))
 
     captured = capfd.readouterr()
     assert captured.err == ""

--- a/nbclient/tests/test_execute.py
+++ b/nbclient/tests/test_execute.py
@@ -285,7 +285,7 @@ def test_async_parallel_notebooks(capfd, tmpdir):
             for label in ("A", "B")
         ]
         loop = asyncio.get_event_loop()
-        loop.run_until_complete(asyncio.wait_for(asyncio.gather(*tasks), timeout=5))
+        loop.run_until_complete(asyncio.gather(*tasks))
 
     captured = capfd.readouterr()
     assert captured.err == ""

--- a/nbclient/tests/test_execute.py
+++ b/nbclient/tests/test_execute.py
@@ -645,7 +645,12 @@ class TestRunCell(ExecutorTestsBase):
     )
     def test_eventual_deadline_iopub(self, executor, cell_mock, message_mock):
         # Process a few messages before raising a timeout from iopub
-        message_mock.side_effect = list(message_mock.side_effect)[:-1] + [Empty()] * 100
+        def message_seq(messages):
+            for message in messages:
+                yield message
+            while True:
+                yield Empty()
+        message_mock.side_effect = message_seq(list(message_mock.side_effect)[:-1])
         executor.kc.shell_channel.get_msg = MagicMock(
             return_value={'parent_header': {'msg_id': executor.parent_id}}
         )


### PR DESCRIPTION
This PR allows for asynchronous cell execution. I just duplicated (with an `async_` prefix) and made asynchronous the `run_cell` method and all its callers for now.
An option would be to keep only the `async` version of the methods and provide a user-facing (non-async) `execute` method that would accept a `asynchronous=False` parameter. If `False`, `execute` would under the hood emulate a blocking call by running `async_execute` in the event loop with `run_until_complete()`.