### PR TITLE
Change default timeout to None

### DIFF
--- a/nbclient/execute.py
+++ b/nbclient/execute.py
@@ -18,7 +18,7 @@ class Executor(LoggingConfigurable):
     """
 
     timeout = Integer(
-        30,
+        None,
         allow_none=True,
         help=dedent(
             """


### PR DESCRIPTION
The new `nbclient` project seems like a good opportunity to fix the wrong default value, see https://github.com/jupyter/nbconvert/issues/791.

When you change `nbconvert` to use `nbclient`, you can still choose to keep the old/wrong default there if you want.