### PR TITLE
Combined run_cell and execute_cell

### DIFF
--- a/nbclient/exceptions.py
+++ b/nbclient/exceptions.py
@@ -23,7 +23,7 @@ class DeadKernelError(RuntimeError):
 
 class CellExecutionComplete(Exception):
     """
-    Used as a control signal for cell execution across run_cell and
+    Used as a control signal for cell execution across execute_cell and
     process_message function calls. Raised when all execution requests
     are completed and no further messages are expected from the kernel
     over zeromq channels.


### PR DESCRIPTION
Addresses #11 
Changed the default for store_history to False (was intended to be changed with nbconvert 6.0). In doing so I found an issue with ipython kernel execution, where execution counts were not tracked when history is disabled. I've made nbclient manage execution_count itself by default now with the ability to control the behavior in execute_cell.
Also removed extra debug prints left in tests