### PR TITLE
Variable name is not used

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -41,7 +41,7 @@ dev_reqs = read_reqs('requirements-dev.txt')
 extras_require = {"test": dev_reqs, "dev": dev_reqs}
 
 setup(
-    name="nbclient",
+    name=name,
     version=version(),
     author='Jupyter Development Team',
     author_email='jupyter@googlegroups.com',


### PR DESCRIPTION
variable name (for name of package) is not used. I figured that it should be passed into the setuptools setup function.