### PR TITLE
Install jupyter_client's master with forward-ported 5.x branch's commits

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,2 @@
 traitlets>=4.2
-jupyter_client>=5.3.4
 nbformat>=5.0

--- a/tox.ini
+++ b/tox.ini
@@ -33,7 +33,7 @@ commands =
     python setup.py sdist --dist-dir={distdir} bdist_wheel --dist-dir={distdir}
     /bin/bash -c 'python -m pip install -U --force-reinstall {distdir}/nbclient*.whl'
     /bin/bash -c 'python -m pip install -U --force-reinstall --no-deps {distdir}/nbclient*.tar.gz'
-    /bin/bash -c 'python -m pip install git+https://git@github.com/davidbrochart/jupyter_client.git@5.x_to_master#egg=jupyter_client'
+    /bin/bash -c 'python -m pip install --ignore-installed git+https://git@github.com/davidbrochart/jupyter_client.git@5.x_to_master#egg=jupyter_client'
 
 [testenv]
 # disable Python's hash randomization for tests that stringify dicts, etc
@@ -51,5 +51,5 @@ basepython =
     docs: python3.6
 deps = .[dev]
 commands =
-    /bin/bash -c 'python -m pip install git+https://git@github.com/davidbrochart/jupyter_client.git@5.x_to_master#egg=jupyter_client'
+    /bin/bash -c 'python -m pip install --ignore-installed git+https://git@github.com/davidbrochart/jupyter_client.git@5.x_to_master#egg=jupyter_client'
     pytest -vv --maxfail=2 --cov=nbclient -W always {posargs}

--- a/tox.ini
+++ b/tox.ini
@@ -33,7 +33,7 @@ commands =
     python setup.py sdist --dist-dir={distdir} bdist_wheel --dist-dir={distdir}
     /bin/bash -c 'python -m pip install -U --force-reinstall {distdir}/nbclient*.whl'
     /bin/bash -c 'python -m pip install -U --force-reinstall --no-deps {distdir}/nbclient*.tar.gz'
-    /bin/bash -c 'python -m pip install -U --force-reinstall --no-deps git+https://git@github.com/davidbrochart/jupyter_client.git@5.x_to_master#egg=jupyter_client'
+    /bin/bash -c 'python -m pip install git+https://git@github.com/davidbrochart/jupyter_client.git@5.x_to_master#egg=jupyter_client'
 
 [testenv]
 # disable Python's hash randomization for tests that stringify dicts, etc
@@ -50,4 +50,6 @@ basepython =
     dist: python3.6
     docs: python3.6
 deps = .[dev]
-commands = pytest -vv --maxfail=2 --cov=nbclient -W always {posargs}
+commands =
+    /bin/bash -c 'python -m pip install git+https://git@github.com/davidbrochart/jupyter_client.git@5.x_to_master#egg=jupyter_client'
+    pytest -vv --maxfail=2 --cov=nbclient -W always {posargs}

--- a/tox.ini
+++ b/tox.ini
@@ -33,6 +33,7 @@ commands =
     python setup.py sdist --dist-dir={distdir} bdist_wheel --dist-dir={distdir}
     /bin/bash -c 'python -m pip install -U --force-reinstall {distdir}/nbclient*.whl'
     /bin/bash -c 'python -m pip install -U --force-reinstall --no-deps {distdir}/nbclient*.tar.gz'
+    /bin/bash -c 'python -m pip install -U --force-reinstall --no-deps git+https://git@github.com/davidbrochart/jupyter_client.git@5.x_to_master#egg=jupyter_client'
 
 [testenv]
 # disable Python's hash randomization for tests that stringify dicts, etc


### PR DESCRIPTION
This is to test `nbclient` with https://github.com/jupyter/jupyter_client/pull/513.