### PR TITLE
Fix nested event loops execution

### DIFF
--- a/nbclient/client.py
+++ b/nbclient/client.py
@@ -6,6 +6,8 @@ from textwrap import dedent
 # contextlib, and we `await yield_()` instead of just `yield`
 from async_generator import asynccontextmanager, async_generator, yield_
 
+import nest_asyncio
+
 from time import monotonic
 from queue import Empty
 import asyncio
@@ -816,3 +818,6 @@ def get_loop():
         loop = asyncio.new_event_loop()
         asyncio.set_event_loop(loop)
     return loop
+
+
+nest_asyncio.apply()

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ traitlets>=4.2
 jupyter_client>=6.0.0
 nbformat>=5.0
 async_generator
+nest_asyncio


### PR DESCRIPTION
Fixes `RuntimeError: This event loop is already running` when `nbclient.execute` is run in an environment where an event loop is already running (e.g. Binder). See https://github.com/jupyter/nbclient/pull/7#issuecomment-592109215.