### PR TITLE
Make nest_asyncio optional

### DIFF
--- a/binder/run_nbclient.ipynb
+++ b/binder/run_nbclient.ipynb
@@ -46,7 +46,7 @@
     "nb = nbf.read('./empty_notebook.ipynb', nbf.NO_CONVERT)\n",
     "\n",
     "# Execute our in-memory notebook, which will now have outputs\n",
-    "nb = nbclient.execute(nb)"
+    "nb = nbclient.execute(nb, nest_asyncio=True)"
    ]
   },
   {

--- a/nbclient/client.py
+++ b/nbclient/client.py
@@ -319,7 +319,16 @@ class NotebookClient(LoggingConfigurable):
         if self.nest_asyncio:
             import nest_asyncio
             nest_asyncio.apply(loop)
-        result = loop.run_until_complete(coro)
+        try:
+            result = loop.run_until_complete(coro)
+        except RuntimeError as e:
+            if str(e) == 'This event loop is already running':
+                raise RuntimeError(
+                    'You are trying to run nbclient in an environment where an '
+                    'event loop is already running. Please pass `nest_asyncio=True` in '
+                    '`NotebookClient.execute` and such methods.'
+                )
+            raise
         return result
 
     def reset_execution_trackers(self):

--- a/nbclient/client.py
+++ b/nbclient/client.py
@@ -6,8 +6,6 @@ from textwrap import dedent
 # contextlib, and we `await yield_()` instead of just `yield`
 from async_generator import asynccontextmanager, async_generator, yield_
 
-import nest_asyncio
-
 from time import monotonic
 from queue import Empty
 import asyncio
@@ -93,6 +91,21 @@ class NotebookClient(LoggingConfigurable):
             If `True`, execution errors are ignored and the execution
             is continued until the end of the notebook. Output from
             exceptions is included in the cell output in both cases.
+            """
+        ),
+    ).tag(config=True)
+
+    nest_asyncio = Bool(
+        False,
+        help=dedent(
+            """
+            If False (default), then blocking functions such as `execute`
+            assume that no event loop is already running. These functions
+            run their async counterparts (e.g. `async_execute`) in an event
+            loop with `asyncio.run_until_complete`, which will fail if an
+            event loop is already running. This can be the case if nbclient
+            is used e.g. in a Jupyter Notebook. In that case, `nest_asyncio`
+            should be set to True.
             """
         ),
     ).tag(config=True)
@@ -367,21 +380,9 @@ class NotebookClient(LoggingConfigurable):
             self.kc.stop_channels()
             self.kc = None
 
-    def execute(self, **kwargs):
-        """
-        Executes each code cell (blocking).
-
-        Returns
-        -------
-        nb : NotebookNode
-            The executed notebook.
-        """
-        loop = get_loop()
-        return loop.run_until_complete(self.async_execute(**kwargs))
-
     async def async_execute(self, **kwargs):
         """
-        Executes each code cell asynchronously.
+        Executes each code cell.
 
         Returns
         -------
@@ -550,48 +551,9 @@ class NotebookClient(LoggingConfigurable):
             if (exec_reply is not None) and exec_reply['content']['status'] == 'error':
                 raise CellExecutionError.from_cell_and_msg(cell, exec_reply['content'])
 
-    def execute_cell(self, cell, cell_index, execution_count=None, store_history=True):
-        """
-        Executes a single code cell (blocking).
-
-        To execute all cells see :meth:`execute`.
-
-        Parameters
-        ----------
-        cell : nbformat.NotebookNode
-            The cell which is currently being processed.
-        cell_index : int
-            The position of the cell within the notebook object.
-        execution_count : int
-            The execution count to be assigned to the cell (default: Use kernel response)
-        store_history : bool
-            Determines if history should be stored in the kernel (default: False).
-            Specific to ipython kernels, which can store command histories.
-
-        Returns
-        -------
-        output : dict
-            The execution output payload (or None for no output).
-
-        Raises
-        ------
-        CellExecutionError
-            If execution failed and should raise an exception, this will be raised
-            with defaults about the failure.
-
-        Returns
-        -------
-        cell : NotebookNode
-            The cell which was just processed.
-        """
-        loop = get_loop()
-        return loop.run_until_complete(
-            self.async_execute_cell(cell, cell_index, execution_count, store_history)
-        )
-
     async def async_execute_cell(self, cell, cell_index, execution_count=None, store_history=True):
         """
-        Executes a single code cell asynchronously.
+        Executes a single code cell.
 
         To execute all cells see :meth:`execute`.
 
@@ -788,6 +750,24 @@ class NotebookClient(LoggingConfigurable):
         return encoded_buffers
 
 
+def make_blocking(async_method):
+    def blocking_method(self, *args, **kwargs):
+        try:
+            loop = asyncio.get_event_loop()
+        except RuntimeError:
+            loop = asyncio.new_event_loop()
+            asyncio.set_event_loop(loop)
+        if self.nest_asyncio:
+            import nest_asyncio
+            nest_asyncio.apply(loop)
+        return loop.run_until_complete(async_method(self, *args, **kwargs))
+    return blocking_method
+
+
+NotebookClient.execute = make_blocking(NotebookClient.async_execute)
+NotebookClient.execute_cell = make_blocking(NotebookClient.async_execute_cell)
+
+
 def execute(nb, cwd=None, km=None, **kwargs):
     """Execute a notebook's code, updating outputs within the notebook object.
 
@@ -809,15 +789,3 @@ def execute(nb, cwd=None, km=None, **kwargs):
     if cwd is not None:
         resources['metadata'] = {'path': cwd}
     return NotebookClient(nb=nb, resources=resources, km=km, **kwargs).execute()
-
-
-def get_loop():
-    try:
-        loop = asyncio.get_event_loop()
-    except RuntimeError:
-        loop = asyncio.new_event_loop()
-        asyncio.set_event_loop(loop)
-    return loop
-
-
-nest_asyncio.apply()

--- a/nbclient/tests/fake_kernelmanager.py
+++ b/nbclient/tests/fake_kernelmanager.py
@@ -1,7 +1,7 @@
-from jupyter_client.manager import KernelManager
+from jupyter_client.manager import AsyncKernelManager
 
 
-class FakeCustomKernelManager(KernelManager):
+class FakeCustomKernelManager(AsyncKernelManager):
     expected_methods = {'__init__': 0, 'client': 0, 'start_kernel': 0}
 
     def __init__(self, *args, **kwargs):
@@ -9,10 +9,10 @@ class FakeCustomKernelManager(KernelManager):
         self.expected_methods['__init__'] += 1
         super(FakeCustomKernelManager, self).__init__(*args, **kwargs)
 
-    def start_kernel(self, *args, **kwargs):
+    async def start_kernel(self, *args, **kwargs):
         self.log.info('FakeCustomKernelManager started a kernel')
         self.expected_methods['start_kernel'] += 1
-        return super(FakeCustomKernelManager, self).start_kernel(*args, **kwargs)
+        return await super(FakeCustomKernelManager, self).start_kernel(*args, **kwargs)
 
     def client(self, *args, **kwargs):
         self.log.info('FakeCustomKernelManager created a client')

--- a/nbclient/tests/test_client.py
+++ b/nbclient/tests/test_client.py
@@ -492,7 +492,7 @@ while True: continue
         km = executor.start_kernel_manager()
 
         with patch.object(km, "is_alive") as alive_mock:
-            alive_mock.return_value = False
+            alive_mock.return_value = make_async(False)
             # Will be a RuntimeError or subclass DeadKernelError depending
             # on if jupyter_client or nbconvert catches the dead client first
             with pytest.raises(RuntimeError):

--- a/nbclient/tests/test_client.py
+++ b/nbclient/tests/test_client.py
@@ -492,7 +492,7 @@ while True: continue
         km = executor.start_kernel_manager()
 
         with patch.object(km, "is_alive") as alive_mock:
-            alive_mock.return_value = make_async(False)
+            alive_mock.return_value = False
             # Will be a RuntimeError or subclass DeadKernelError depending
             # on if jupyter_client or nbconvert catches the dead client first
             with pytest.raises(RuntimeError):

--- a/nbclient/util.py
+++ b/nbclient/util.py
@@ -1,0 +1,47 @@
+"""General utility methods"""
+
+# Copyright (c) Jupyter Development Team.
+# Distributed under the terms of the Modified BSD License.
+
+import asyncio
+
+
+def run_sync(coro):
+    """Runs a coroutine and blocks until it has executed.
+
+    An event loop is created if no one already exists. If an event loop is
+    already running, this event loop execution is nested into the already
+    running one if `nest_asyncio` is set to True.
+
+    Parameters
+    ----------
+    coro : coroutine
+        The coroutine to be executed.
+
+    Returns
+    -------
+    result :
+        Whatever the coroutine returns.
+    """
+    def wrapped(self, *args, **kwargs):
+        try:
+            loop = asyncio.get_event_loop()
+        except RuntimeError:
+            loop = asyncio.new_event_loop()
+            asyncio.set_event_loop(loop)
+        if self.nest_asyncio:
+            import nest_asyncio
+            nest_asyncio.apply(loop)
+        try:
+            result = loop.run_until_complete(coro(self, *args, **kwargs))
+        except RuntimeError as e:
+            if str(e) == 'This event loop is already running':
+                raise RuntimeError(
+                    'You are trying to run nbclient in an environment where an '
+                    'event loop is already running. Please pass `nest_asyncio=True` in '
+                    '`NotebookClient.execute` and such methods.'
+                )
+            raise
+        return result
+    wrapped.__doc__ = coro.__doc__
+    return wrapped

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 traitlets>=4.2
-jupyter_client>=6.0.0
+jupyter_client>=6.1.0
 nbformat>=5.0
 async_generator
 nest_asyncio


### PR DESCRIPTION
In nbclient, we chose to implement blocking methods such as `execute` by running their async counterparts (e.g. `async_execute`) in an event loop (with `asyncio.run_until_complete`), to avoid code duplication. This can be an issue in environments where an event loop is already running, such as a Jupyter Notebook. [nest_asyncio](https://github.com/erdewit/nest_asyncio) solves this issue, but it doesn't play well with tornado (see https://github.com/tornadoweb/tornado/issues/2753). This will impact applications such as Voila (which will use the async methods of nbclient and so won't need to nest event loops). We should for now make the use of nest_asyncio an opt-in.