### PR TITLE
Add reset_kc option to reset_execution_trackers

### DIFF
--- a/nbclient/tests/test_client.py
+++ b/nbclient/tests/test_client.py
@@ -558,14 +558,14 @@ while True: continue
         executor.execute()
         # we didn't ask to reset the kernel client, a new one must have been created
         kc = executor.kc
-        self.assertNotEqual(kc, None)
+        assert kc is not None
         executor.execute()
         # we didn't ask to reset the kernel client, the previously created one must have been reused
-        self.assertEqual(kc, executor.kc)
+        assert kc == executor.kc
         executor.execute(reset_kc=True)
         # we asked to reset the kernel client, the previous one must have been cleaned up,
         # a new one must have been created and also cleaned up
-        self.assertEqual(executor.kc, None)
+        assert executor.kc is None
 
     def test_custom_kernel_manager(self):
         from .fake_kernelmanager import FakeCustomKernelManager

--- a/nbclient/tests/test_client.py
+++ b/nbclient/tests/test_client.py
@@ -544,6 +544,29 @@ while True: continue
             else:
                 assert u"# üñîçø∂é".encode('utf8', 'replace') in str(exc.value)
 
+    def test_reset_kernel_client(self):
+        filename = os.path.join(current_dir, 'files', 'HelloWorld.ipynb')
+
+        with io.open(filename) as f:
+            input_nb = nbformat.read(f, 4)
+
+        executor = NotebookClient(
+            input_nb,
+            resources=self.build_resources(),
+        )
+
+        executor.execute()
+        # we didn't ask to reset the kernel client, a new one must have been created
+        kc = executor.kc
+        self.assertNotEqual(kc, None)
+        executor.execute()
+        # we didn't ask to reset the kernel client, the previously created one must have been reused
+        self.assertEqual(kc, executor.kc)
+        executor.execute(reset_kc=True)
+        # we asked to reset the kernel client, the previous one must have been cleaned up,
+        # a new one must have been created and also cleaned up
+        self.assertEqual(executor.kc, None)
+
     def test_custom_kernel_manager(self):
         from .fake_kernelmanager import FakeCustomKernelManager
 


### PR DESCRIPTION
`reset_kc` can also be passed to `async_execute` and `execute` methods (defaults to False: the kernel client won't be reset).