### PR TITLE
Formally → formerly in the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 
 # nbclient
 
-A client library for executing notebooks. Formally nbconvert's ExecutePreprocessor.
+A client library for executing notebooks. Formerly nbconvert's ExecutePreprocessor.
 
 **NBClient** is a tool for executing Jupyter Notebooks.
 


### PR DESCRIPTION
I believe this is a typo, but please feel free to close if I'm mistaken.