### PR TITLE
Support MultiKernelManager

### DIFF
--- a/nbclient/client.py
+++ b/nbclient/client.py
@@ -373,7 +373,8 @@ class NotebookClient(LoggingConfigurable):
         if hasattr(self.km, 'ipykernel') and self.km.ipykernel and self.ipython_hist_file:
             self.extra_arguments += ['--HistoryManager.hist_file={}'.format(self.ipython_hist_file)]
 
-        kernel_id = await ensure_async(self.km.start_kernel(extra_arguments=self.extra_arguments, **kwargs))
+        kernel_id = await ensure_async(self.km.start_kernel(extra_arguments=self.extra_arguments,
+                                       **kwargs))
 
         # if self.km is not a KernelManager, it's probably a MultiKernelManager
         try:
@@ -383,7 +384,8 @@ class NotebookClient(LoggingConfigurable):
             try:
                 km = self.km.get_kernel(kernel_id)
             except AttributeError:
-                raise AttributeError(f'{self.km=} has no client() or get_kernel() method, what is this?')
+                raise AttributeError(f'{self.km=} has no client() or get_kernel() method, '
+                                     'what is this?')
 
         self.kc = km.client()
         await ensure_async(self.kc.start_channels())

--- a/nbclient/client.py
+++ b/nbclient/client.py
@@ -370,6 +370,8 @@ class NotebookClient(LoggingConfigurable):
         if resource_path and 'cwd' not in kwargs:
             kwargs["cwd"] = resource_path
 
+        # if self.km is a MultiKernelManager, it doesn't have an ipykernel attribute
+        # so no extra_arguments can be passed
         if hasattr(self.km, 'ipykernel') and self.km.ipykernel and self.ipython_hist_file:
             self.extra_arguments += ['--HistoryManager.hist_file={}'.format(self.ipython_hist_file)]
 

--- a/nbclient/client.py
+++ b/nbclient/client.py
@@ -384,8 +384,8 @@ class NotebookClient(LoggingConfigurable):
             try:
                 km = self.km.get_kernel(kernel_id)
             except AttributeError:
-                raise AttributeError(f'{self.km=} has no client() or get_kernel() method, '
-                                     'what is this?')
+                raise AttributeError('self.km={} has no client() or get_kernel() method, '
+                                     'what is this?'.format(self.km))
 
         self.kc = km.client()
         await ensure_async(self.kc.start_channels())

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,6 +1,7 @@
 codecov
 coverage
 ipython
+ipykernel
 ipywidgets
 pytest>=4.1
 pytest-cov>=2.6.1


### PR DESCRIPTION
In order to remove [some boilerplate code in Voila](https://github.com/voila-dashboards/voila/blob/1c9ca89d5915db42179755fc0936b2f9cdd314cf/voila/handler.py#L116-L138), it would be nice if `NotebookClient` could accept a `MultiKernelManager` instead of a `KernelManager`. Their APIs differ, but a `MultiKernelManager`'s underlying `KernelManager` can be retrieved through the `get_kernel(kernel_id)` method.
This PR makes `(async_)start_new_kernel_client` support a `MultiKernelManager` by checking the presence of a `client()` method, which only a `KernelManager` has.