### PR TITLE
changelog markdown

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -36,6 +36,7 @@ extensions = [
     'sphinx.ext.intersphinx',
     'sphinx.ext.mathjax',
     'sphinx.ext.napoleon',
+    'myst_parser',
 ]
 
 # Add any paths that contain templates here, relative to this directory.
@@ -44,7 +45,7 @@ templates_path = ['_templates']
 # The suffix(es) of source filenames.
 # You can specify multiple suffix as a list of string:
 #
-source_suffix = ['.rst', '.md', '.ipynb']
+source_suffix = ['.rst', '.md']
 
 # The master toctree document.
 master_doc = 'index'

--- a/docs/requirements-doc.txt
+++ b/docs/requirements-doc.txt
@@ -2,3 +2,4 @@ Sphinx>=1.7
 sphinx-book-theme
 mock
 moto
+myst-parser


### PR DESCRIPTION
Fixes #57 

The problem was that the changelog is written in markdown but we didn't configure sphinx to be able to parse markdown. This adds the myst-parser which gives us markdown parsing

@palewire FYI in case you wanna see the actual changelog :-) https://25-233653381-gh.circle-artifacts.com/0/html/changelog.html