### PR TITLE
Use KernelManager's graceful shutdown rather than KILLing kernels 

### DIFF
--- a/nbclient/client.py
+++ b/nbclient/client.py
@@ -455,8 +455,9 @@ class NotebookClient(LoggingConfigurable):
         try:
             loop.add_signal_handler(signal.SIGINT, on_signal)
             loop.add_signal_handler(signal.SIGTERM, on_signal)
-        except NotImplementedError:
-            # Windows does not support signals.
+        except (NotImplementedError, RuntimeError):
+            # NotImplementedError: Windows does not support signals.
+            # RuntimeError: Raised when add_signal_handler is called outside the main thread
             pass
 
         if not self.km.has_kernel:
@@ -471,7 +472,7 @@ class NotebookClient(LoggingConfigurable):
             try:
                 loop.remove_signal_handler(signal.SIGINT)
                 loop.remove_signal_handler(signal.SIGTERM)
-            except NotImplementedError:
+            except (NotImplementedError, RuntimeError):
                 pass
 
     async def async_execute(self, reset_kc=False, **kwargs):

--- a/nbclient/client.py
+++ b/nbclient/client.py
@@ -291,7 +291,7 @@ class NotebookClient(LoggingConfigurable):
         ----------
         nb : NotebookNode
             Notebook being executed.
-        km : KernerlManager (optional)
+        km : KernelManager (optional)
             Optional kernel manager. If none is provided, a kernel manager will
             be created.
         """

--- a/nbclient/client.py
+++ b/nbclient/client.py
@@ -359,7 +359,7 @@ class NotebookClient(LoggingConfigurable):
         finally:
             # Remove any state left over even if we failed to stop the kernel
             await ensure_async(self.km.cleanup())
-            if self.kc:
+            if getattr(self, "kc"):
                 await ensure_async(self.kc.stop_channels())
                 self.kc = None
 

--- a/nbclient/client.py
+++ b/nbclient/client.py
@@ -1,3 +1,4 @@
+import atexit
 import datetime
 import base64
 from textwrap import dedent
@@ -438,6 +439,8 @@ class NotebookClient(LoggingConfigurable):
         if self.km is None:
             self.start_kernel_manager()
 
+        atexit.register(self._cleanup_kernel)
+
         if not self.km.has_kernel:
             await self.async_start_new_kernel_client(**kwargs)
         try:
@@ -445,6 +448,7 @@ class NotebookClient(LoggingConfigurable):
         finally:
             if cleanup_kc:
                 await self._async_cleanup_kernel()
+            atexit.unregister(self._cleanup_kernel)
 
     async def async_execute(self, reset_kc=False, **kwargs):
         """

--- a/nbclient/client.py
+++ b/nbclient/client.py
@@ -350,7 +350,8 @@ class NotebookClient(LoggingConfigurable):
         now = self.shutdown_kernel == "immediate"
         try:
             # Queue the manager to kill the process, and recover gracefully if it's already dead.
-            await ensure_async(self.km.shutdown_kernel(now=now))
+            if await ensure_async(self.km.is_alive()):
+                await ensure_async(self.km.shutdown_kernel(now=now))
         except RuntimeError as e:
             # The error isn't specialized, so we have to check the message
             if 'No kernel is running!' not in str(e):


### PR DESCRIPTION
I think the way it was implemented was possibly because of how earlier KernelManager versions behaved, but since that's pinned to >6.1, it should be fine to leverage the graceful shutdown methods available. 

KernelManager's graceful shutdown first does the equivalent of KernelClient.shutdown() ie. sending a shutdown message using the shutdown. Then it polls the kernel to see if it's still alive, and has a configurable timeout after which, it force KILLs the kernel. So the behaviour here shouldn't really change outside the extra wait time waiting for things to shut down gracefully (which possibly fixes things that had been breaking)