### PR TITLE
Automatically use nest_asyncio if the event loop is already running

### DIFF
--- a/binder/run_nbclient.ipynb
+++ b/binder/run_nbclient.ipynb
@@ -46,7 +46,7 @@
     "nb = nbf.read('./empty_notebook.ipynb', nbf.NO_CONVERT)\n",
     "\n",
     "# Execute our in-memory notebook, which will now have outputs\n",
-    "nb = nbclient.execute(nb, nest_asyncio=True)"
+    "nb = nbclient.execute(nb)"
    ]
   },
   {
@@ -103,7 +103,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.3"
+   "version": "3.8.2"
   },
   "widgets": {
    "application/vnd.jupyter.widget-state+json": {

--- a/nbclient/client.py
+++ b/nbclient/client.py
@@ -103,21 +103,6 @@ class NotebookClient(LoggingConfigurable):
         ),
     ).tag(config=True)
 
-    nest_asyncio = Bool(
-        False,
-        help=dedent(
-            """
-            If False (default), then blocking functions such as `execute`
-            assume that no event loop is already running. These functions
-            run their async counterparts (e.g. `async_execute`) in an event
-            loop with `asyncio.run_until_complete`, which will fail if an
-            event loop is already running. This can be the case if nbclient
-            is used e.g. in a Jupyter Notebook. In that case, `nest_asyncio`
-            should be set to True.
-            """
-        ),
-    ).tag(config=True)
-
     force_raise_errors = Bool(
         False,
         help=dedent(


### PR DESCRIPTION
This PR removes the `nest_asyncio` trait from the `NotebookClient` class, and thus the keyword argument `nest_asyncio` for e.g. the `execute()` method.