### PR TITLE
fix: always run a coroutine and work with tornado

### DIFF
--- a/binder/run_nbclient.ipynb
+++ b/binder/run_nbclient.ipynb
@@ -46,7 +46,7 @@
     "nb = nbf.read('./empty_notebook.ipynb', nbf.NO_CONVERT)\n",
     "\n",
     "# Execute our in-memory notebook, which will now have outputs\n",
-    "nb = nbclient.execute(nb, nest_asyncio=True)"
+    "nb = nbclient.execute(nb)"
    ]
   },
   {

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -5,6 +5,7 @@
 ### Major Changes
 
 - Mimic an Output widget at the frontend so that the Output widget behaves correctly [#68](https://github.com/jupyter/nbclient/pull/68)
+- Nested asyncio is automatic, and works with Tornado [#71](https://github.com/jupyter/nbclient/pull/71)
 
 ## 0.3.1
 

--- a/nbclient/client.py
+++ b/nbclient/client.py
@@ -103,21 +103,6 @@ class NotebookClient(LoggingConfigurable):
         ),
     ).tag(config=True)
 
-    nest_asyncio = Bool(
-        False,
-        help=dedent(
-            """
-            If False (default), then blocking functions such as `execute`
-            assume that no event loop is already running. These functions
-            run their async counterparts (e.g. `async_execute`) in an event
-            loop with `asyncio.run_until_complete`, which will fail if an
-            event loop is already running. This can be the case if nbclient
-            is used e.g. in a Jupyter Notebook. In that case, `nest_asyncio`
-            should be set to True.
-            """
-        ),
-    ).tag(config=True)
-
     force_raise_errors = Bool(
         False,
         help=dedent(

--- a/nbclient/tests/util.py
+++ b/nbclient/tests/util.py
@@ -1,0 +1,57 @@
+import asyncio
+
+import tornado
+
+from nbclient.util import run_sync
+
+
+@run_sync
+async def some_async_function():
+    await asyncio.sleep(0.01)
+    return 42
+
+
+def test_nested_asyncio_with_existing_ioloop():
+    ioloop = asyncio.new_event_loop()
+    try:
+        asyncio.set_event_loop(ioloop)
+        assert some_async_function() == 42
+        assert asyncio.get_event_loop() is ioloop
+    finally:
+        asyncio._set_running_loop(None)  # it seems nest_asyncio doesn't reset this
+
+
+def test_nested_asyncio_with_no_ioloop():
+    asyncio.set_event_loop(None)
+    try:
+        assert some_async_function() == 42
+    finally:
+        asyncio._set_running_loop(None)  # it seems nest_asyncio doesn't reset this
+
+
+def test_nested_asyncio_with_tornado():
+    # This tests if tornado accepts the pure-Python Futures, see
+    # https://github.com/tornadoweb/tornado/issues/2753
+    # https://github.com/erdewit/nest_asyncio/issues/23
+    asyncio.set_event_loop(asyncio.new_event_loop())
+    ioloop = tornado.ioloop.IOLoop.current()
+
+    async def some_async_function():
+        future = asyncio.ensure_future(asyncio.sleep(0.1))
+        # this future is a different future after nested-asyncio has patched
+        # the asyncio module, check if tornado likes it:
+        ioloop.add_future(future, lambda f: f.result())
+        await future
+        return 42
+
+    def some_sync_function():
+        return run_sync(some_async_function)()
+
+    async def run():
+        # calling some_async_function directly should work
+        assert await some_async_function() == 42
+        # but via a sync function (using nested-asyncio) can lead to issues:
+        # https://github.com/tornadoweb/tornado/issues/2753
+        assert some_sync_function() == 42
+
+    ioloop.run_sync(run)


### PR DESCRIPTION
This is a port of what I use in [vaex](https://github.com/vaexio/vaex/blob/10e1d5077021a0590d3750d62d4d56a27a84af82/packages/vaex-core/vaex/asyncio.py)

This has been running for quite a while on CI, and seems pretty solid. If an event loop is present  it will patch it with nested-asyncio and will also patch tornado, which should solve:
 * https://github.com/nteract/papermill/issues/490

Alternative to https://github.com/jupyter/nbclient/pull/67

See also https://github.com/erdewit/nest_asyncio/issues/23 and https://github.com/tornadoweb/tornado/issues/2753

This also checks to see if it is being run in an IPython context (I'm not sure the check makes sense, I just check if it is imported), and will give an error if not v7+, otherwise cells in a notebook may run out of order (a known? issue with older versions of IPython I believe), see also https://github.com/erdewit/nest_asyncio/issues/9