### PR TITLE
fix: if a comm target is not know, give a warning and continue

### DIFF
--- a/nbclient/client.py
+++ b/nbclient/client.py
@@ -853,11 +853,15 @@ class NotebookClient(LoggingConfigurable):
         # There are cases where we need to mimic a frontend, to get similar behaviour as
         # when using the Output widget from Jupyter lab/notebook
         if msg['msg_type'] == 'comm_open':
-            handler = self.comm_open_handlers.get(msg['content'].get('target_name'))
-            comm_id = msg['content']['comm_id']
-            comm_object = handler(msg)
-            if comm_object:
-                self.comm_objects[comm_id] = comm_object
+            target = msg['content'].get('target_name')
+            handler = self.comm_open_handlers.get(target)
+            if handler:
+                comm_id = msg['content']['comm_id']
+                comm_object = handler(msg)
+                if comm_object:
+                    self.comm_objects[comm_id] = comm_object
+            else:
+                self.log.warning(f'No handler found for comm target {target!r}')
         elif msg['msg_type'] == 'comm_msg':
             content = msg['content']
             comm_id = msg['content']['comm_id']

--- a/nbclient/tests/files/Other Comms.ipynb
+++ b/nbclient/tests/files/Other Comms.ipynb
@@ -1,0 +1,67 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2020-05-29T11:16:26.365338Z",
+     "start_time": "2020-05-29T11:16:26.362047Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "from ipykernel.comm import Comm"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2020-05-29T11:16:26.377700Z",
+     "start_time": "2020-05-29T11:16:26.371603Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "comm = Comm('this-comm-tests-a-missing-handler', data={'id': 'foo'})"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2020-05-29T11:16:26.584520Z",
+     "start_time": "2020-05-29T11:16:26.581213Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "comm.send(data={'id': 'bar'})"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.7.3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/nbclient/tests/test_client.py
+++ b/nbclient/tests/test_client.py
@@ -243,6 +243,7 @@ def notebook_resources():
 @pytest.mark.parametrize(
     ["input_name", "opts"],
     [
+        ("Other Comms.ipynb", dict(kernel_name="python")),
         ("Clear Output.ipynb", dict(kernel_name="python")),
         ("Empty Cell.ipynb", dict(kernel_name="python")),
         ("Factorials.ipynb", dict(kernel_name="python")),


### PR DESCRIPTION
This was the reason https://github.com/voila-dashboards/voila/pull/621 failed, since that was using the matplotlib comm.

We now give a warning:
```bash
$ python -m nbconvert nbclient/tests/files/Other\ Comms.ipynb --execute
.....
[NbConvertApp] WARNING | No handler found for comm target 'this-comm-tests-a-missing-handler'
```

and just continue executing.