### PR TITLE
Fix for windows/python<3.7

### DIFF
--- a/nbclient/__init__.py
+++ b/nbclient/__init__.py
@@ -1,2 +1,17 @@
+import sys
+import subprocess
 from .client import NotebookClient, execute  # noqa: F401
 from ._version import version as __version__  # noqa: F401
+
+
+def _cleanup():
+    pass
+
+
+# patch subprocess on Windows for python<3.7
+# see https://bugs.python.org/issue37380
+# the fix for python3.7: https://github.com/python/cpython/pull/15706/files
+if sys.platform == 'win32':
+    if sys.version_info < (3, 7):
+        subprocess._cleanup = _cleanup
+        subprocess._active = None


### PR DESCRIPTION
This patches python's `subprocess` module as it is done in https://github.com/python/cpython/pull/15706.
We suspect #73 is due to https://bugs.python.org/issue37380, but the fix was not back-ported to python<3.7.