### PR TITLE
cleanup async_start_new_kernel_client

### DIFF
--- a/nbclient/client.py
+++ b/nbclient/client.py
@@ -362,7 +362,7 @@ class NotebookClient(LoggingConfigurable):
 
     _cleanup_kernel = run_sync(_async_cleanup_kernel)
 
-    async def async_start_new_kernel_client(self, **kwargs) -> t.Tuple[KernelClient, str]:
+    async def async_start_new_kernel_client(self, **kwargs) -> KernelClient:
         """Creates a new kernel client.
 
         Parameters

--- a/nbclient/tests/test_client.py
+++ b/nbclient/tests/test_client.py
@@ -20,8 +20,7 @@ from ..exceptions import CellExecutionError
 
 from traitlets import TraitError
 from nbformat import NotebookNode
-from jupyter_client.asynchronous import AsyncKernelClient
-from jupyter_client import KernelManager, MultiKernelManager
+from jupyter_client import KernelManager
 from jupyter_client.kernelspec import KernelSpecManager
 from nbconvert.filters import strip_ansi
 from testpath import modified_env
@@ -414,36 +413,13 @@ def test_startnewkernel_with_kernelmanager():
     nb = nbformat.v4.new_notebook()
     km = KernelManager()
     executor = NotebookClient(nb, km=km)
-    kc, kernel_id = executor.start_new_kernel_client()
-    # no kernel_id for a single kernel manager
-    assert kernel_id is None
+    kc = executor.start_new_kernel_client()
     # prove it initalized client
     assert kc is not None
     # since we are not using the setup_kernel context manager,
     # cleanup has to be done manually
     kc.shutdown()
     km.cleanup()
-    kc.stop_channels()
-
-
-def test_startnewkernel_with_multikernelmanager():
-    nb = nbformat.v4.new_notebook()
-    km = MultiKernelManager()
-    executor = NotebookClient(nb, km=km)
-    kc, kernel_id = executor.start_new_kernel_client()
-    # a multi kernel manager always gives back an id to the started kernel
-    assert kernel_id is not None
-    # prove it initalized an async client
-    assert isinstance(kc, AsyncKernelClient)
-    # since we are not using the setup_kernel context manager,
-    # cleanup has to be done manually
-    kc.shutdown()
-    km.cleanup(kernel_id)
-    km.remove_kernel(kernel_id)
-    # check that the kernel doesn't exist anymore
-    with pytest.raises(KeyError) as e_info:
-        km.get_kernel(kernel_id)
-    assert str(e_info.value) == "'Kernel with id not found: {}'".format(kernel_id)
     kc.stop_channels()
 
 


### PR DESCRIPTION
Fixes #91 

This makes it clear that the `km` attribute should *always* be a `KernelManager` and not a `MultiKernelManager`. These two classes have different APIs and behave significantly differently and we should not have handled the case of a `MultiKernelManager` in this function.

I would be in favor of calling it a 0.5.0 when this gets in.