### PR TITLE
Split start_new_kernel_client into kernel and client creation

### DIFF
--- a/nbclient/tests/test_client.py
+++ b/nbclient/tests/test_client.py
@@ -413,6 +413,7 @@ def test_startnewkernel_with_kernelmanager():
     nb = nbformat.v4.new_notebook()
     km = KernelManager()
     executor = NotebookClient(nb, km=km)
+    executor.start_new_kernel()
     kc = executor.start_new_kernel_client()
     # prove it initalized client
     assert kc is not None
@@ -526,7 +527,7 @@ while True: continue
 
         with pytest.raises(TimeoutError):
             executor.execute()
-        km = executor.start_kernel_manager()
+        km = executor.create_kernel_manager()
 
         async def is_alive():
             return False


### PR DESCRIPTION
Separates `(async_)start_new_kernel_client` into:
- `(async_)start_new_kernel`: starts a new kernel.
- `(async_)start_new_kernel_client`: starts a new client of the kernel.

This gives more flexibility as to creating the kernel and/or the client from outside. Internally, both methods are called so it doesn't change anything.

Also in this PR:
- `start_kernel_manager` renamed to `create_kernel_manager` (see #92).
- `self.owns_km` indicates if the kernel manager is created by the `NotebookClient` or if it is passed from outside. If the `NotebookClient` owns the kernel manager, the cleanup of the kernel (client and manager) will be done by default. If not, the cleanup won't be done by default (previously, it was always done by default).