### PR TITLE
Applied fix for duplicate HistoryManager setting being added

### DIFF
--- a/nbclient/client.py
+++ b/nbclient/client.py
@@ -378,7 +378,12 @@ class NotebookClient(LoggingConfigurable):
         if resource_path and 'cwd' not in kwargs:
             kwargs["cwd"] = resource_path
 
-        if hasattr(self.km, 'ipykernel') and self.km.ipykernel and self.ipython_hist_file:
+        has_history_manager_arg = any(
+            arg.startswith('--HistoryManager.hist_file') for arg in self.extra_arguments)
+        if (hasattr(self.km, 'ipykernel')
+                and self.km.ipykernel
+                and self.ipython_hist_file
+                and not has_history_manager_arg):
             self.extra_arguments += ['--HistoryManager.hist_file={}'.format(self.ipython_hist_file)]
 
         await ensure_async(self.km.start_kernel(extra_arguments=self.extra_arguments, **kwargs))

--- a/nbclient/tests/test_client.py
+++ b/nbclient/tests/test_client.py
@@ -424,6 +424,28 @@ def test_startnewkernel_with_kernelmanager():
     kc.stop_channels()
 
 
+def test_start_new_kernel_history_file_setting():
+    nb = nbformat.v4.new_notebook()
+    km = KernelManager()
+    executor = NotebookClient(nb, km=km)
+    kc = km.client()
+
+    # Should start empty
+    assert executor.extra_arguments == []
+    # Should assign memory setting for ipykernel
+    executor.start_new_kernel()
+    assert executor.extra_arguments == ['--HistoryManager.hist_file=:memory:']
+    # Should not add a second hist_file assignment
+    executor.start_new_kernel()
+    assert executor.extra_arguments == ['--HistoryManager.hist_file=:memory:']
+
+    # since we are not using the setup_kernel context manager,
+    # cleanup has to be done manually
+    kc.shutdown()
+    km.cleanup()
+    kc.stop_channels()
+
+
 class TestExecute(NBClientTestsBase):
     """Contains test functions for execute.py"""
 


### PR DESCRIPTION
Fix for https://github.com/jupyter/nbclient/issues/99

I also realized when writing this that the reason we include it in nbclient is actually because ipykernel defaults to persisting all executions in sqlite unless to provide this argument, which can be a security concern in niche situations with a headless executor... plus it avoid sqlite permissions on systems where that occurs (mounted windows setups if I recall).