### PR TITLE
Cleanup references to preprocessor

### DIFF
--- a/docs/client.rst
+++ b/docs/client.rst
@@ -36,8 +36,7 @@ class::
 **Load**: Assuming that ``notebook_filename`` contains the path to a notebook,
 we can load it with::
 
-    with open(notebook_filename) as f:
-        nb = nbformat.read(f, as_version=4)
+    nb = nbformat.read(notebook_filename, as_version=4)
 
 **Configure**: Next, we configure the notebook execution mode::
 
@@ -109,8 +108,7 @@ and raise a ``CellExecutionError``. Conveniently, the source cell causing
 the error and the original error name and message are also printed.
 After an error, we can still save the notebook as before::
 
-    with open('executed_notebook.ipynb', mode='w', encoding='utf-8') as f:
-        nbformat.write(nb, f)
+    nbformat.write(nb, 'executed_notebook.ipynb')
 
 The saved notebook contains the output up until the failing cell,
 and includes a full stack-trace and error (which can help debugging).
@@ -129,8 +127,7 @@ A useful pattern to execute notebooks while handling errors is the following::
         print(msg)
         raise
     finally:
-        with open(notebook_filename_out, mode='w', encoding='utf-8') as f:
-            nbformat.write(nb, f)
+        nbformat.write(nb, notebook_filename_out)
 
 This will save the executed notebook regardless of execution errors.
 In case of errors, however, an additional message is printed and the

--- a/docs/client.rst
+++ b/docs/client.rst
@@ -119,12 +119,11 @@ Handling errors
 ~~~~~~~~~~~~~~~
 A useful pattern to execute notebooks while handling errors is the following::
 
-    from nbconvert.preprocessors import CellExecutionError
+    from nbclient.exceptions import CellExecutionError
 
     try:
-        out = ep.preprocess(nb, {'metadata': {'path': run_path}})
+        client.execute()
     except CellExecutionError:
-        out = None
         msg = 'Error executing the notebook "%s".\n\n' % notebook_filename
         msg += 'See notebook "%s" for the traceback.' % notebook_filename_out
         print(msg)

--- a/nbclient/client.py
+++ b/nbclient/client.py
@@ -66,7 +66,7 @@ class NotebookClient(LoggingConfigurable):
             is raised.
 
             Returning ``None`` or ``-1`` will disable the timeout for the cell.
-            Not setting ``timeout_func`` will cause the preprocessor to
+            Not setting ``timeout_func`` will cause the client to
             default to using the ``timeout`` trait for all cells. The
             ``timeout_func`` trait overrides ``timeout`` if it is not ``None``.
             """

--- a/nbclient/tests/base.py
+++ b/nbclient/tests/base.py
@@ -4,10 +4,9 @@ from nbformat import v4 as nbformat
 
 
 class NBClientTestsBase(unittest.TestCase):
-    """Contains test functions preprocessor tests"""
 
     def build_notebook(self, with_json_outputs=False):
-        """Build a notebook in memory for use with preprocessor tests"""
+        """Build a notebook in memory for use with NotebookClient tests"""
 
         outputs = [
             nbformat.new_output("stream", name="stdout", text="a"),


### PR DESCRIPTION
There were a few places still using the ExecutePreprocessor names instead of the names in nbclient.

I also changed some examples to pass filenames to `nbformat.read()` and `nbformat.write()`. This is a shortcut that I'm pretty sure has worked for years.