### PR TITLE
typo fix

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -47,7 +47,7 @@ setup(
     author='Jupyter Development Team',
     author_email='jupyter@googlegroups.com',
     url='https://jupyter.org',
-    description="A client library for executing notebooks. Formally nbconvert's ExecutePreprocessor.",
+    description="A client library for executing notebooks. Formerly nbconvert's ExecutePreprocessor.",
     long_description=long_description,
     long_description_content_type='text/markdown',
     packages=['nbclient'],


### PR DESCRIPTION
Formally execute preprocessor → Formerly execute preprocessor

Sorry, should have bundled this with the previous PR, but only spotted this now.