### PR TITLE
Update kernel client class if it's the synchronous version

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -127,3 +127,6 @@ dmypy.json
 
 # Pyre type checker
 .pyre/
+
+# Pycharm stuff
+.idea/

--- a/nbclient/client.py
+++ b/nbclient/client.py
@@ -341,7 +341,7 @@ class NotebookClient(LoggingConfigurable):
             self.km = self.kernel_manager_class(kernel_name=self.kernel_name, config=self.config)
 
         # If the current kernel manager is still using the default (synchronous) KernelClient class,
-        # switch to the async version since that's what NBClient expects.  Any custom kernel client 
+        # switch to the async version since that's what NBClient expects.  Any custom kernel client
         # classes must also support async method calls.
         if self.km.client_class == 'jupyter_client.client.KernelClient':
             self.km.client_class = 'jupyter_client.asynchronous.AsyncKernelClient'

--- a/nbclient/client.py
+++ b/nbclient/client.py
@@ -341,8 +341,7 @@ class NotebookClient(LoggingConfigurable):
             self.km = self.kernel_manager_class(kernel_name=self.kernel_name, config=self.config)
 
         # If the current kernel manager is still using the default (synchronous) KernelClient class,
-        # switch to the async version since that's what NBClient expects.  Any custom kernel client
-        # classes must also support async method calls.
+        # switch to the async version since that's what NBClient prefers.
         if self.km.client_class == 'jupyter_client.client.KernelClient':
             self.km.client_class = 'jupyter_client.asynchronous.AsyncKernelClient'
 

--- a/nbclient/client.py
+++ b/nbclient/client.py
@@ -339,7 +339,13 @@ class NotebookClient(LoggingConfigurable):
             self.km = self.kernel_manager_class(config=self.config)
         else:
             self.km = self.kernel_manager_class(kernel_name=self.kernel_name, config=self.config)
-        self.km.client_class = 'jupyter_client.asynchronous.AsyncKernelClient'
+
+        # If the current kernel manager is still using the default (synchronous) KernelClient class,
+        # switch to the async version since that's what NBClient expects.  Any custom kernel client 
+        # classes must also support async method calls.
+        if self.km.client_class == 'jupyter_client.client.KernelClient':
+            self.km.client_class = 'jupyter_client.asynchronous.AsyncKernelClient'
+
         return self.km
 
     async def _async_cleanup_kernel(self) -> None:

--- a/nbclient/util.py
+++ b/nbclient/util.py
@@ -23,7 +23,7 @@ def check_patch_tornado() -> None:
     """If tornado is imported, add the patched asyncio.Future to its tuple of acceptable Futures"""
     # original from vaex/asyncio.py
     if 'tornado' in sys.modules:
-        import tornado.concurrent
+        import tornado.concurrent  # type: ignore
         if asyncio.Future not in tornado.concurrent.FUTURES:
             tornado.concurrent.FUTURES = \
                 tornado.concurrent.FUTURES + (asyncio.Future, )  # type: ignore


### PR DESCRIPTION
Users wishing to bring their own kernel manager implementations that also happen to include a kernel client implementation were unable to do so because NBClient was unconditionally adjusting the kernel client class to juptyer_client's `AsyncKernelClient` class.  This change makes that adjustment conditional only when the kernel manager's configured `kernel_client_class` specifies jupyter_client's older (and synchronous) `KernelClient`.  When that class is not currently configured on the kernel manager, whatever `kernel_client_class` that is configured will be used.