### PR TITLE
Remove references to Executor

### DIFF
--- a/docs/client.rst
+++ b/docs/client.rst
@@ -68,7 +68,7 @@ in the file ``executed_notebook.ipynb``.
 Execution arguments (traitlets)
 -------------------------------
 
-The arguments passed to :class:`Executor` are configuration options
+The arguments passed to :class:`NotebookClient` are configuration options
 called `traitlets <https://traitlets.readthedocs.io/en/stable>`_.
 There are many cool things about traitlets. For example,
 they enforce the input type, and they can be accessed/modified as
@@ -156,7 +156,7 @@ converting to html.
 We can tell nbclient to not store the state using the `store_widget_state`
 argument::
 
-    executor = Executor(nb, store_widget_state=False)
+    client = NotebookClient(nb, store_widget_state=False)
 
 This widget rendering is not performed against a browser during execution, so
 only widget default states or states manipulated via user code will be

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -115,10 +115,7 @@ html_static_path = ['_static']
 
 # Custom sidebar templates, must be a dictionary that maps document names
 # to template names.
-#
-# This is required for the alabaster theme
-# refs: http://alabaster.readthedocs.io/en/latest/installation.html#sidebars
-html_sidebars = {'**': ['about.html', 'navigation.html', 'relations.html', 'searchbox.html']}
+#html_sidebars = {}
 
 html_title = "nbclient"
 


### PR DESCRIPTION
I guess this was a possible name for the class at one point, but it's called NotebookClient now.