### PR TITLE
fix: ensure_async should not silently eat errors and return the coro instead of the result

### DIFF
--- a/nbclient/util.py
+++ b/nbclient/util.py
@@ -81,13 +81,6 @@ async def ensure_async(obj: Union[Awaitable, Any]) -> Any:
     and await it if it was not already awaited.
     """
     if inspect.isawaitable(obj):
-        try:
-            result = await obj
-        except RuntimeError as e:
-            if str(e) == 'cannot reuse already awaited coroutine':
-                # obj is already the coroutine's result
-                return obj
-            raise
-        return result
-    # obj doesn't need to be awaited
-    return obj
+        return await obj
+    else:
+        return obj


### PR DESCRIPTION
We are now returning the coroutine itself, instead of the results of the coroutine.

This gets triggered when a coroutine that is wrapped actually awaits the same coroutine twice. In my case in voila, this caused kernel_id https://github.com/voila-dashboards/voila/blob/4b323460fd5d7e6a7203ff0492607c13c8eb6f25/voila/handler.py#L166 to be assigned the coroutine, because the `start_kernel` had an exception.

Note that this change causes the tests to fail, I'm not sure how to fix this.