### PR TITLE
windows py38 and py39

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,9 +15,6 @@ jobs:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
         python-version: [ 3.6, 3.7, 3.8, 3.9 ]
-        exclude:
-          - os: windows-latest
-            python-version: 3.9
     env:
         OS: ${{ matrix.os }}
         PYTHON: '3.9'

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -17,8 +17,6 @@ jobs:
         python-version: [ 3.6, 3.7, 3.8, 3.9 ]
         exclude:
           - os: windows-latest
-            python-version: 3.8
-          - os: windows-latest
             python-version: 3.9
     env:
         OS: ${{ matrix.os }}

--- a/nbclient/__init__.py
+++ b/nbclient/__init__.py
@@ -13,5 +13,5 @@ def _cleanup() -> None:
 # the fix for python3.7: https://github.com/python/cpython/pull/15706/files
 if sys.platform == 'win32':
     if sys.version_info < (3, 7):
-        subprocess._cleanup = _cleanup
-        subprocess._active = None
+        subprocess._cleanup = _cleanup  # type: ignore
+        subprocess._active = None  # type:ignore

--- a/nbclient/client.py
+++ b/nbclient/client.py
@@ -33,7 +33,7 @@ from .util import run_sync, ensure_async
 from .output_widget import OutputWidget
 
 
-if os_name = "nt":
+if os_name == "nt":
     # patch c.f. https://github.com/tornadoweb/tornado/issues/2608#issuecomment-491489432
     asyncio.set_event_loop_policy(asyncio.WindowsSelectorEventLoopPolicy())  # python-3.8.x
 

--- a/nbclient/client.py
+++ b/nbclient/client.py
@@ -1,3 +1,4 @@
+from os import name as os_name
 import atexit
 import collections
 import datetime
@@ -32,8 +33,9 @@ from .util import run_sync, ensure_async
 from .output_widget import OutputWidget
 
 
-# patch c.f. https://github.com/tornadoweb/tornado/issues/2608#issuecomment-491489432
-asyncio.set_event_loop_policy(asyncio.WindowsSelectorEventLoopPolicy())  # python-3.8.x
+if os_name = "nt":
+    # patch c.f. https://github.com/tornadoweb/tornado/issues/2608#issuecomment-491489432
+    asyncio.set_event_loop_policy(asyncio.WindowsSelectorEventLoopPolicy())  # python-3.8.x
 
 
 def timestamp() -> str:

--- a/nbclient/client.py
+++ b/nbclient/client.py
@@ -32,6 +32,10 @@ from .util import run_sync, ensure_async
 from .output_widget import OutputWidget
 
 
+# patch c.f. https://github.com/tornadoweb/tornado/issues/2608#issuecomment-491489432
+asyncio.set_event_loop_policy(asyncio.WindowsSelectorEventLoopPolicy())  # python-3.8.x
+
+
 def timestamp() -> str:
     return datetime.datetime.utcnow().isoformat() + 'Z'
 

--- a/nbclient/client.py
+++ b/nbclient/client.py
@@ -34,7 +34,7 @@ from .util import run_sync, ensure_async
 from .output_widget import OutputWidget
 
 
-if os_name == "nt" and version_info.major == 3 and version_info.minor >= 8: 
+if os_name == "nt" and version_info.major == 3 and version_info.minor >= 8:
     # patch c.f. https://github.com/tornadoweb/tornado/issues/2608#issuecomment-491489432
     asyncio.set_event_loop_policy(asyncio.WindowsSelectorEventLoopPolicy())   # type: ignore
 

--- a/nbclient/client.py
+++ b/nbclient/client.py
@@ -1,4 +1,5 @@
 from os import name as os_name
+from sys import version_info
 import atexit
 import collections
 import datetime
@@ -33,7 +34,7 @@ from .util import run_sync, ensure_async
 from .output_widget import OutputWidget
 
 
-if os_name == "nt":
+if os_name == "nt" and version_info.major == 3 and version_info.minor >= 8:     # type: ignore
     # patch c.f. https://github.com/tornadoweb/tornado/issues/2608#issuecomment-491489432
     asyncio.set_event_loop_policy(asyncio.WindowsSelectorEventLoopPolicy())  # python-3.8.x
 

--- a/nbclient/client.py
+++ b/nbclient/client.py
@@ -34,9 +34,9 @@ from .util import run_sync, ensure_async
 from .output_widget import OutputWidget
 
 
-if os_name == "nt" and version_info.major == 3 and version_info.minor >= 8:     # type: ignore
+if os_name == "nt" and version_info.major == 3 and version_info.minor >= 8: 
     # patch c.f. https://github.com/tornadoweb/tornado/issues/2608#issuecomment-491489432
-    asyncio.set_event_loop_policy(asyncio.WindowsSelectorEventLoopPolicy())  # python-3.8.x
+    asyncio.set_event_loop_policy(asyncio.WindowsSelectorEventLoopPolicy())   # type: ignore
 
 
 def timestamp() -> str:

--- a/nbclient/client.py
+++ b/nbclient/client.py
@@ -34,7 +34,7 @@ from .util import run_sync, ensure_async
 from .output_widget import OutputWidget
 
 
-if os_name == "nt" and version_info.major == 3 and version_info.minor >= 8:
+if os_name == "nt" and version_info.major >= (3, 8):
     # patch c.f. https://github.com/tornadoweb/tornado/issues/2608#issuecomment-491489432
     asyncio.set_event_loop_policy(asyncio.WindowsSelectorEventLoopPolicy())   # type: ignore
 

--- a/nbclient/client.py
+++ b/nbclient/client.py
@@ -34,7 +34,7 @@ from .util import run_sync, ensure_async
 from .output_widget import OutputWidget
 
 
-if os_name == "nt" and version_info.major >= (3, 8):
+if os_name == "nt" and version_info >= (3, 8):
     # patch c.f. https://github.com/tornadoweb/tornado/issues/2608#issuecomment-491489432
     asyncio.set_event_loop_policy(asyncio.WindowsSelectorEventLoopPolicy())   # type: ignore
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,8 +1,8 @@
 [tox]
 skipsdist = true
 envlist = py{36,37,38, 39}, flake8, mypy, dist-{win, linux}, manifest, docs
-requires =
-    tox-factor
+# requires =
+#     tox-factor
 
 [gh-actions]
 python =

--- a/tox.ini
+++ b/tox.ini
@@ -44,8 +44,8 @@ skip_install = true
 # Have to use /bin/bash or the `*` will cause that argument to get quoted by the tox command line...
 commands =
     python setup.py sdist --dist-dir={distdir} bdist_wheel --dist-dir={distdir}
-    /bin/bash -c 'python -m pip install -U --force-reinstall {distdir}/nbclient*.whl'
-    /bin/bash -c 'python -m pip install -U --force-reinstall --no-deps {distdir}/nbclient*.tar.gz'
+    bash -c 'python -m pip install -U --force-reinstall {distdir}/nbclient*.whl'
+    bash -c 'python -m pip install -U --force-reinstall --no-deps {distdir}/nbclient*.tar.gz'
 
 [testenv]
 # disable Python's hash randomization for tests that stringify dicts, etc

--- a/tox.ini
+++ b/tox.ini
@@ -45,16 +45,16 @@ commands =
 skip_install = true
 platform =
     win: win|msys
-    linux-mac: linux|darwin
+    linux: linux|darwin
 allowlist_externals = 
     win: powershell
     linux: bash  
-# Have to use /bin/bash or the `*` will cause that argument to get quoted by the tox command line...
+
 commands =
     python setup.py sdist --dist-dir={distdir} bdist_wheel --dist-dir={distdir}
     win: powershell Get-ChildItem -Path {distdir} -Filter nbclient*.whl | foreach \{python -m pip install -U --force-reinstall $_.FullName\}
     win: powershell Get-ChildItem -Path {distdir} -Filter nbclient*.tar.gz | foreach \{python -m pip install -U --force-reinstall --no-deps $_.FullName\}
-
+    # Have to use /bin/bash or the `*` will cause that argument to get quoted by the tox command line...
     linux: bash -c 'python -m pip install -U --force-reinstall {distdir}/nbclient*.whl'
     linux: bash -c 'python -m pip install -U --force-reinstall --no-deps {distdir}/nbclient*.tar.gz'
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,13 +1,15 @@
 [tox]
 skipsdist = true
-envlist = py{36,37,38, 39}, flake8, mypy, dist, manifest, docs
+envlist = py{36,37,38, 39}, flake8, mypy, dist-{win, linux}, manifest, docs
+requires =
+    tox-factor
 
 [gh-actions]
 python =
     3.6: py36
     3.7: py37
     3.8: py38
-    3.9: py39, flake8, mypy, dist, manifest
+    3.9: py39, flake8, mypy, dist-{win, linux}, manifest
 
 # Linters
 [testenv:flake8]
@@ -39,13 +41,22 @@ commands =
     python -c 'import pathlib; print("documentation available under file://\{0\}".format(pathlib.Path(r"{toxworkdir}") / "docs_out" / "index.html"))'
 
 # Distro
-[testenv:dist]
+[testenv:dist-{win, linux}]
 skip_install = true
+platform =
+    win: win|msys
+    linux-mac: linux|darwin
+allowlist_externals = 
+    win: powershell
+    linux: bash  
 # Have to use /bin/bash or the `*` will cause that argument to get quoted by the tox command line...
 commands =
     python setup.py sdist --dist-dir={distdir} bdist_wheel --dist-dir={distdir}
-    bash -c 'python -m pip install -U --force-reinstall {distdir}/nbclient*.whl'
-    bash -c 'python -m pip install -U --force-reinstall --no-deps {distdir}/nbclient*.tar.gz'
+    win: powershell Get-ChildItem -Path {distdir} -Filter nbclient*.whl | foreach \{python -m pip install -U --force-reinstall $_.FullName\}
+    win: powershell Get-ChildItem -Path {distdir} -Filter nbclient*.tar.gz | foreach \{python -m pip install -U --force-reinstall --no-deps $_.FullName\}
+
+    linux: bash -c 'python -m pip install -U --force-reinstall {distdir}/nbclient*.whl'
+    linux: bash -c 'python -m pip install -U --force-reinstall --no-deps {distdir}/nbclient*.tar.gz'
 
 [testenv]
 # disable Python's hash randomization for tests that stringify dicts, etc


### PR DESCRIPTION
fixes #85, fixes #125

* patched according to https://github.com/tornadoweb/tornado/issues/2608#issuecomment-491489432
  * added version selection and type ignore 
* included windows python 3.8 and python 3.9
* updated tox for multiple platform usage
* added type ignore for version_info < (3, 7)
  * the type ignore should be made os dependent

forgot to squash my dev branch ;)

poss. 
* fixes https://github.com/executablebooks/jupyter-book/issues/958
* fixes https://github.com/executablebooks/jupyter-book/issues/906