### PR TITLE
Print useful error message on exception

### DIFF
--- a/nbclient/exceptions.py
+++ b/nbclient/exceptions.py
@@ -88,7 +88,10 @@ class CellExecutionError(CellControlSignal):
         """Instantiate from a code cell object and a message contents
         (message is either execute_reply or error)
         """
-        tb = '\n'.join(msg.get('traceback', []))
+        if msg.get('traceback', []):
+            tb = '\n'.join(msg.get('traceback', []))
+        else:
+            tb = ''
         return cls(
             exec_err_msg.format(
                 cell=cell,

--- a/nbclient/exceptions.py
+++ b/nbclient/exceptions.py
@@ -88,10 +88,7 @@ class CellExecutionError(CellControlSignal):
         """Instantiate from a code cell object and a message contents
         (message is either execute_reply or error)
         """
-        if msg.get('traceback', []):
-            tb = '\n'.join(msg.get('traceback', []))
-        else:
-            tb = ''
+        tb = '\n'.join(msg.get('traceback', []) or [])
         return cls(
             exec_err_msg.format(
                 cell=cell,


### PR DESCRIPTION
Sometimes apparently the 'traceback' can be None, which results in throwing a `TypeError` exception. 

With this fix the actual underlying error will get printed, so that users can fix it.

Fixes #141.