### PR TITLE
Add `skip-execution` cell tag functionality

### DIFF
--- a/nbclient/client.py
+++ b/nbclient/client.py
@@ -802,6 +802,10 @@ class NotebookClient(LoggingConfigurable):
         if cell.cell_type != 'code' or not cell.source.strip():
             self.log.debug("Skipping non-executing cell %s", cell_index)
             return cell
+        
+        if "skip-execution" in cell.metadata.get("tags", []):
+            self.log.debug("Skipping tagged cell %s", cell_index)
+            return cell
 
         if self.record_timing and 'execution' not in cell['metadata']:
             cell['metadata']['execution'] = {}

--- a/nbclient/client.py
+++ b/nbclient/client.py
@@ -812,7 +812,7 @@ class NotebookClient(LoggingConfigurable):
         if cell.cell_type != 'code' or not cell.source.strip():
             self.log.debug("Skipping non-executing cell %s", cell_index)
             return cell
-        
+
         if self.skip_cells_with_tag in cell.metadata.get("tags", []):
             self.log.debug("Skipping tagged cell %s", cell_index)
             return cell

--- a/nbclient/client.py
+++ b/nbclient/client.py
@@ -139,7 +139,7 @@ class NotebookClient(LoggingConfigurable):
         ),
     ).tag(config=True)
 
-    skip_execution_tag: str = Unicode(
+    skip_cells_with_tag: str = Unicode(
         'skip-execution',
         help=dedent(
             """
@@ -813,7 +813,7 @@ class NotebookClient(LoggingConfigurable):
             self.log.debug("Skipping non-executing cell %s", cell_index)
             return cell
         
-        if self.skip_execution_tag in cell.metadata.get("tags", []):
+        if self.skip_cells_with_tag in cell.metadata.get("tags", []):
             self.log.debug("Skipping tagged cell %s", cell_index)
             return cell
 

--- a/nbclient/client.py
+++ b/nbclient/client.py
@@ -139,6 +139,16 @@ class NotebookClient(LoggingConfigurable):
         ),
     ).tag(config=True)
 
+    skip_execution_tag: str = Unicode(
+        'skip-execution',
+        help=dedent(
+            """
+            Name of the cell tag to use to,
+            to denote a cell that should be skipped.
+            """
+        ),
+    ).tag(config=True)
+
     extra_arguments: t.List = List(Unicode()).tag(config=True)
 
     kernel_name: str = Unicode(
@@ -803,7 +813,7 @@ class NotebookClient(LoggingConfigurable):
             self.log.debug("Skipping non-executing cell %s", cell_index)
             return cell
         
-        if "skip-execution" in cell.metadata.get("tags", []):
+        if self.skip_execution_tag in cell.metadata.get("tags", []):
             self.log.debug("Skipping tagged cell %s", cell_index)
             return cell
 

--- a/nbclient/client.py
+++ b/nbclient/client.py
@@ -143,8 +143,7 @@ class NotebookClient(LoggingConfigurable):
         'skip-execution',
         help=dedent(
             """
-            Name of the cell tag to use to,
-            to denote a cell that should be skipped.
+            Name of the cell tag to use to denote a cell that should be skipped.
             """
         ),
     ).tag(config=True)

--- a/nbclient/tests/files/Skip Execution with Cell Tag.ipynb
+++ b/nbclient/tests/files/Skip Execution with Cell Tag.ipynb
@@ -1,0 +1,37 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "source": [
+    "print(\"a long running cell\")"
+   ],
+   "outputs": [],
+   "metadata": {
+    "tags": [
+     "skip-execution"
+    ]
+   }
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "source": [
+    "print('ok')"
+   ],
+   "outputs": [
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": [
+      "ok\n"
+     ]
+    }
+   ],
+   "metadata": {}
+  }
+ ],
+ "metadata": {},
+ "nbformat": 4,
+ "nbformat_minor": 1
+}

--- a/nbclient/tests/test_client.py
+++ b/nbclient/tests/test_client.py
@@ -257,6 +257,7 @@ def notebook_resources():
         ("JupyterWidgets.ipynb", dict(kernel_name="python")),
         ("Skip Exceptions with Cell Tags.ipynb", dict(kernel_name="python")),
         ("Skip Exceptions.ipynb", dict(kernel_name="python", allow_errors=True)),
+        ("Skip Execution with Cell Tag.ipynb", dict(kernel_name="python")),
         ("SVG.ipynb", dict(kernel_name="python")),
         ("Unicode.ipynb", dict(kernel_name="python")),
         ("UnicodePy3.ipynb", dict(kernel_name="python")),


### PR DESCRIPTION
This is something that has been requested and up-voted in https://github.com/executablebooks/jupyter-book/issues/833

I guess this is the simplest implementation, although happy to discuss (a) if you would back this idea in the first place and (b) is you think any more configuration is needed (e.g. at the traitlets level)