### PR TITLE
PoP for Inline variable insertion in markdown

### DIFF
--- a/nbclient/client.py
+++ b/nbclient/client.py
@@ -1062,7 +1062,7 @@ class NotebookClient(LoggingConfigurable):
             finally:
                 raise
         self._check_raise_for_error(cell, exec_reply)
-        attachments = {key: val["data"] for key, val in exec_reply["content"]["user_expressions"].items()}
+        attachments = {key: val["data"] if "data" in val else {"traceback": "\n".join(val["traceback"])} for key, val in exec_reply["content"]["user_expressions"].items()}
         cell.setdefault("attachments", {})
         # remove old expressions from cell
         cell["attachments"] = {key: val for key, val in cell["attachments"].items() if not key.startswith(MD_EXPRESSIONS_PREFIX)}

--- a/nbclient/client.py
+++ b/nbclient/client.py
@@ -1033,7 +1033,7 @@ class NotebookClient(LoggingConfigurable):
         parent_msg_id = await ensure_async(
             self.kc.execute(
                 '',
-                silent=True,
+                silent=False,
                 user_expressions=user_expressions,
             )
         )

--- a/nbclient/tests/files/Markdown_expressions.ipynb
+++ b/nbclient/tests/files/Markdown_expressions.ipynb
@@ -13,6 +13,10 @@
   {
    "cell_type": "markdown",
    "metadata": {},
+   "attachments": {
+    "md-expr-0": {"text/plain": "1"},
+    "md-expr-1": {"text/plain": "'c'"}
+   },
    "source": [
     "# Variables\n",
     "\n",

--- a/nbclient/tests/files/Markdown_expressions.ipynb
+++ b/nbclient/tests/files/Markdown_expressions.ipynb
@@ -15,12 +15,13 @@
    "metadata": {},
    "attachments": {
     "md-expr-0": {"text/plain": "1"},
-    "md-expr-1": {"text/plain": "'c'"}
+    "md-expr-1": {"text/plain": "'c'"},
+    "md-expr-2": {"traceback": "\u001b[0;31mNameError\u001b[0m\u001b[0;31m:\u001b[0m name 'c' is not defined\n"}
    },
    "source": [
     "# Variables\n",
     "\n",
-    "{{ a }} {{ b }}"
+    "{{ a }} {{ b }} {{ c }}"
     ]
   }
  ],

--- a/nbclient/tests/files/Markdown_expressions.ipynb
+++ b/nbclient/tests/files/Markdown_expressions.ipynb
@@ -1,0 +1,26 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "a = 1\n",
+    "b = 'c'"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Variables\n",
+    "\n",
+    "{{ a }} {{ b }}"
+    ]
+  }
+ ],
+ "metadata": {},
+ "nbformat": 4,
+ "nbformat_minor": 0
+}

--- a/nbclient/tests/test_client.py
+++ b/nbclient/tests/test_client.py
@@ -232,7 +232,7 @@ def assert_notebooks_equal(expected, actual):
 
         expected_execution_count = expected_cell.get('attachments', None)
         actual_execution_count = actual_cell.get('attachments', None)
-        assert expected_execution_count == actual_execution_count        
+        assert expected_execution_count == actual_execution_count
 
 
 def notebook_resources():
@@ -252,6 +252,7 @@ def filter_messages_on_error_output(err_output):
 
     return os.linesep.join(filtered_result)
 
+
 def parse_md_expressions(source: str) -> list:
     """
     Parse markdown expressions from a string.
@@ -261,9 +262,12 @@ def parse_md_expressions(source: str) -> list:
     """
     from markdown_it import MarkdownIt, tree
     from mdit_py_plugins.substitution import substitution_plugin
+
     mdit = MarkdownIt().use(substitution_plugin)
     tokens = tree.SyntaxTreeNode(mdit.parse(source))
-    return [t.content for t in tokens.walk() if t.type in ['substitution_inline', 'substitution_block']]
+    return [
+        t.content for t in tokens.walk() if t.type in ['substitution_inline', 'substitution_block']
+    ]
 
 
 @pytest.mark.parametrize(
@@ -288,7 +292,10 @@ def parse_md_expressions(source: str) -> list:
         ("UnicodePy3.ipynb", dict(kernel_name="python")),
         ("update-display-id.ipynb", dict(kernel_name="python")),
         ("Check History in Memory.ipynb", dict(kernel_name="python")),
-        ("Markdown_expressions.ipynb", dict(kernel_name="python", parse_md_expressions=parse_md_expressions)),
+        (
+            "Markdown_expressions.ipynb",
+            dict(kernel_name="python", parse_md_expressions=parse_md_expressions),
+        ),
     ],
 )
 def test_run_all_notebooks(input_name, opts):

--- a/nbclient/tests/test_client.py
+++ b/nbclient/tests/test_client.py
@@ -248,6 +248,19 @@ def filter_messages_on_error_output(err_output):
 
     return os.linesep.join(filtered_result)
 
+def parse_md_expressions(source: str) -> list:
+    """
+    Parse markdown expressions from a string.
+
+    :param source: The source string to parse.
+    :return: A list of markdown expressions.
+    """
+    from markdown_it import MarkdownIt, tree
+    from mdit_py_plugins.substitution import substitution_plugin
+    mdit = MarkdownIt().use(substitution_plugin)
+    tokens = tree.SyntaxTreeNode(mdit.parse(source))
+    return [t.content for t in tokens.walk() if t.type in ['substitution_inline', 'substitution_block']]
+
 
 @pytest.mark.parametrize(
     ["input_name", "opts"],
@@ -271,6 +284,7 @@ def filter_messages_on_error_output(err_output):
         ("UnicodePy3.ipynb", dict(kernel_name="python")),
         ("update-display-id.ipynb", dict(kernel_name="python")),
         ("Check History in Memory.ipynb", dict(kernel_name="python")),
+        ("Markdown_expressions.ipynb", dict(kernel_name="python", parse_md_expressions=parse_md_expressions)),
     ],
 )
 def test_run_all_notebooks(input_name, opts):

--- a/nbclient/tests/test_client.py
+++ b/nbclient/tests/test_client.py
@@ -230,6 +230,10 @@ def assert_notebooks_equal(expected, actual):
         actual_execution_count = actual_cell.get('execution_count', None)
         assert expected_execution_count == actual_execution_count
 
+        expected_execution_count = expected_cell.get('attachments', None)
+        actual_execution_count = actual_cell.get('attachments', None)
+        assert expected_execution_count == actual_execution_count        
+
 
 def notebook_resources():
     """

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -15,3 +15,4 @@ pip>=18.1
 wheel>=0.31.0
 setuptools>=38.6.0
 twine>=1.11.0
+markdown-it-py[plugins]~=1.0.0


### PR DESCRIPTION
This is a hacked together Proof-of-Principle for https://discourse.jupyter.org/t/inline-variable-insertion-in-markdown/10525/87

nbclient would accept an additional configuration trait: `parse_md_expressions`, which is a callable that takes a Markdown string and extracts from it a list of substitution expressions.

If present, these are then parsed to the kernel, via `user_expressions`, to return their mime-bundles, which are then stored as attachments on the Markdown cell


