### PR TITLE
Added Pipfile stuff to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -89,7 +89,8 @@ ipython_config.py
 #   However, in case of collaboration, if having platform-specific dependencies or dependencies
 #   having no cross-platform support, pipenv may install dependencies that don't work, or not
 #   install all needed dependencies.
-#Pipfile.lock
+Pipfile
+Pipfile.lock
 
 # PEP 582; used by e.g. github.com/David-OConnor/pyflow
 __pypackages__/


### PR DESCRIPTION
If this project is all in on requirements.txt, we should ignore any Pipfiles. This will allow devs who prefer to use that approach to work without accidentally littering their files in the repo. 