### PR TITLE
Use codecov Github action v2

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -51,7 +51,7 @@ jobs:
     - name: Run the tests
       run: tox
     - name: Upload coverage to Codecov
-      uses: codecov/codecov-action@v1
+      uses: codecov/codecov-action@v2
       with:
           file: ./coverage.xml
           flags: unittests

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -47,7 +47,7 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install -e .[test]
-        pip install tox coverage codecov tox-gh-actions
+        pip install tox coverage tox-gh-actions
     - name: Run the tests
       run: tox
     - name: Upload coverage to Codecov


### PR DESCRIPTION
The v1 action is deprecated due to security concerns, and will stop working in a few months:

https://github.com/marketplace/actions/codecov
https://about.codecov.io/blog/introducing-codecovs-new-uploader/