### PR TITLE
fix: updating buffers overwrote previous buffers

### DIFF
--- a/nbclient/client.py
+++ b/nbclient/client.py
@@ -334,7 +334,7 @@ class NotebookClient(LoggingConfigurable):
         self.code_cells_executed = 0
         self._display_id_map = {}
         self.widget_state: t.Dict[str, t.Dict] = {}
-        self.widget_buffers: t.Dict[str, t.Dict[str, t.Dict[str, str]]] = {}
+        self.widget_buffers: t.Dict[str, t.Dict[t.Tuple[str, ...], t.Dict[str, str]]] = {}
         # maps to list of hooks, where the last is used, this is used
         # to support nested use of output widgets.
         self.output_hook_stack: t.Any = collections.defaultdict(list)
@@ -995,7 +995,9 @@ class NotebookClient(LoggingConfigurable):
                 if comm_id not in self.widget_buffers:
                     self.widget_buffers[comm_id] = {}
                 # for each comm, the path uniquely identifies a buffer
-                new_buffers = {tuple(k["path"]): k for k in self._get_buffer_data(msg)}
+                new_buffers: t.Dict[t.Tuple[str, ...], t.Dict[str, str]] = {
+                    tuple(k["path"]): k for k in self._get_buffer_data(msg)
+                }
                 self.widget_buffers[comm_id].update(new_buffers)
         # There are cases where we need to mimic a frontend, to get similar behaviour as
         # when using the Output widget from Jupyter lab/notebook

--- a/nbclient/client.py
+++ b/nbclient/client.py
@@ -991,11 +991,12 @@ class NotebookClient(LoggingConfigurable):
         if self.store_widget_state and 'state' in data:  # ignore custom msg'es
             self.widget_state.setdefault(content['comm_id'], {}).update(data['state'])
             if 'buffer_paths' in data and data['buffer_paths']:
-                if content['comm_id'] not in self.widget_buffers:
-                    self.widget_buffers[content['comm_id']] = {}
+                comm_id = content['comm_id']
+                if comm_id not in self.widget_buffers:
+                    self.widget_buffers[comm_id] = {}
                 # for each comm, the path uniquely identifies a buffer
                 new_buffers = {tuple(k["path"]): k for k in self._get_buffer_data(msg)}
-                self.widget_buffers[content['comm_id']].update(new_buffers)
+                self.widget_buffers[comm_id].update(new_buffers)
         # There are cases where we need to mimic a frontend, to get similar behaviour as
         # when using the Output widget from Jupyter lab/notebook
         if msg['msg_type'] == 'comm_open':

--- a/nbclient/tests/test_client.py
+++ b/nbclient/tests/test_client.py
@@ -1084,7 +1084,7 @@ class TestRunCell(NBClientTestsBase):
                 'comm_id': 'foobar',
                 'data': {'state': {'foo2': 'bar2'}, 'buffer_paths': [['path2']]},
             },
-        }
+        },
     )
     def test_widget_comm_buffer_messages(self, executor, cell_mock, message_mock):
         executor.execute_cell(cell_mock, 0)
@@ -1092,8 +1092,10 @@ class TestRunCell(NBClientTestsBase):
         assert message_mock.call_count == 3
         assert executor.widget_state == {'foobar': {'foo': 'bar', 'foo2': 'bar2'}}
         assert executor.widget_buffers == {
-            'foobar': {('path',): {'data': 'MTIz', 'encoding': 'base64', 'path': ['path']},
-                       ('path2',): {'data': 'MTIz', 'encoding': 'base64', 'path': ['path2']}}
+            'foobar': {
+                ('path',): {'data': 'MTIz', 'encoding': 'base64', 'path': ['path']},
+                ('path2',): {'data': 'MTIz', 'encoding': 'base64', 'path': ['path2']},
+            }
         }
         # Ensure no outputs were generated
         assert cell_mock.outputs == []

--- a/nbclient/tests/test_client.py
+++ b/nbclient/tests/test_client.py
@@ -1051,17 +1051,49 @@ class TestRunCell(NBClientTestsBase):
             'buffers': [b'123'],
             'content': {
                 'comm_id': 'foobar',
-                'data': {'state': {'foo': 'bar'}, 'buffer_paths': ['path']},
+                'data': {'state': {'foo': 'bar'}, 'buffer_paths': [['path']]},
             },
         }
     )
-    def test_widget_comm_buffer_message(self, executor, cell_mock, message_mock):
+    def test_widget_comm_buffer_message_single(self, executor, cell_mock, message_mock):
         executor.execute_cell(cell_mock, 0)
         # A comm message with buffer info followed by an idle
         assert message_mock.call_count == 2
         assert executor.widget_state == {'foobar': {'foo': 'bar'}}
         assert executor.widget_buffers == {
-            'foobar': [{'data': 'MTIz', 'encoding': 'base64', 'path': 'path'}]
+            'foobar': {('path',): {'data': 'MTIz', 'encoding': 'base64', 'path': ['path']}}
+        }
+        # Ensure no outputs were generated
+        assert cell_mock.outputs == []
+
+    @prepare_cell_mocks(
+        {
+            'msg_type': 'comm',
+            'header': {'msg_type': 'comm'},
+            'buffers': [b'123'],
+            'content': {
+                'comm_id': 'foobar',
+                'data': {'state': {'foo': 'bar'}, 'buffer_paths': [['path']]},
+            },
+        },
+        {
+            'msg_type': 'comm',
+            'header': {'msg_type': 'comm'},
+            'buffers': [b'123'],
+            'content': {
+                'comm_id': 'foobar',
+                'data': {'state': {'foo2': 'bar2'}, 'buffer_paths': [['path2']]},
+            },
+        }
+    )
+    def test_widget_comm_buffer_messages(self, executor, cell_mock, message_mock):
+        executor.execute_cell(cell_mock, 0)
+        # A comm message with buffer info followed by an idle
+        assert message_mock.call_count == 3
+        assert executor.widget_state == {'foobar': {'foo': 'bar', 'foo2': 'bar2'}}
+        assert executor.widget_buffers == {
+            'foobar': {('path',): {'data': 'MTIz', 'encoding': 'base64', 'path': ['path']},
+                       ('path2',): {'data': 'MTIz', 'encoding': 'base64', 'path': ['path2']}}
         }
         # Ensure no outputs were generated
         assert cell_mock.outputs == []


### PR DESCRIPTION
We now add the buffers, and overwrite old ones based on the path.

For instance, if you did in the notebook:
```
mark.x = np.arange(10)
mark.y = np.arange(1, 11)  # this would clear the buffer for x
```

Now we keep the buffer for x and y.