### PR TITLE
Move IPYKERNEL_CELL_NAME from tox to pytest

### DIFF
--- a/nbclient/tests/conftest.py
+++ b/nbclient/tests/conftest.py
@@ -1,0 +1,6 @@
+import os
+
+# This is important for ipykernel to show the same string
+# instead of randomly generated file names in outputs.
+# See: https://github.com/ipython/ipykernel/blob/360685c6/ipykernel/compiler.py#L50-L55
+os.environ["IPYKERNEL_CELL_NAME"] = "<IPY-INPUT>"

--- a/tox.ini
+++ b/tox.ini
@@ -39,7 +39,6 @@ commands =
 # disable Python's hash randomization for tests that stringify dicts, etc
 setenv =
     PYTHONHASHSEED = 0
-    IPYKERNEL_CELL_NAME = <IPY-INPUT>
 passenv = *
 basepython =
     py36: python3.6


### PR DESCRIPTION
This allows pytest to be executed directly without tox and without
manual setting of the variable. Tox works well as before.

Possible fix for #157 