### PR TITLE
Extend the ignored part of IPython outputs

### DIFF
--- a/nbclient/tests/test_client.py
+++ b/nbclient/tests/test_client.py
@@ -28,10 +28,14 @@ from .base import NBClientTestsBase
 
 addr_pat = re.compile(r'0x[0-9a-f]{7,9}')
 current_dir = os.path.dirname(__file__)
-ipython_input_pat = re.compile(r'<ipython-input-\d+-[0-9a-f]+>')
+ipython_input_pat = re.compile(
+    r'(<ipython-input-\d+-[0-9a-f]+>|<IPY-INPUT>) in (<module>|<cell line: \d>\(\))'
+)
 # Tracebacks look different in IPython 8,
 # see: https://github.com/ipython/ipython/blob/master/docs/source/whatsnew/version8.rst#traceback-improvements  # noqa
-ipython8_input_pat = re.compile(r'Input In \[\d+\],')
+ipython8_input_pat = re.compile(
+    r'(Input In \[\d+\]|<IPY-INPUT>), in (<module>|<cell line: \d>\(\))'
+)
 
 hook_methods = [
     "on_cell_start",


### PR DESCRIPTION
With IPython 8.1, there is again a difference in tracebacks which causes three tests of nbclient to fail like this:
```
E             Full diff:
E               [
E                {'ename': 'KeyboardInterrupt',
E                 'evalue': '',
E                 'output_type': 'error',
E                 'traceback': ['---------------------------------------------------------------------------',
E                               'KeyboardInterrupt                         Traceback (most '
E                               'recent call last)',
E             -                 '<IPY-INPUT> in <cell line: 1>()\n'
E             ?                                  ^ ---------- --
E             +                 '<IPY-INPUT> in <module>\n'
E             ?                                  ^^^^^
E                               '----> 1 while True: continue\n',
E                               'KeyboardInterrupt: ']},
E               ]

nbclient/tests/test_client.py:231: AssertionError
…
=========================== short test summary info ============================
FAILED nbclient/tests/test_client.py::test_run_all_notebooks[Interrupt.ipynb-opts6]
FAILED nbclient/tests/test_client.py::test_run_all_notebooks[Skip Exceptions with Cell Tags.ipynb-opts8]
FAILED nbclient/tests/test_client.py::test_run_all_notebooks[Skip Exceptions.ipynb-opts9]
============ 3 failed, 73 passed, 106 warnings in 65.37s (0:01:05) =============
```

It seems to me that it's good idea to extend the ignored part of IPython input so I've prepared the regexes for that.
