### PR TITLE
Update docstring

### DIFF
--- a/nbclient/client.py
+++ b/nbclient/client.py
@@ -123,7 +123,7 @@ class NotebookClient(LoggingConfigurable):
         help=dedent(
             """
             If ``False`` (default), when a cell raises an error the
-            execution is stopped and a `CellExecutionError`
+            execution is stopped and a :py:class:`nbclient.exceptions.CellExecutionError`
             is raised, except if the error name is in
             ``allow_error_names``.
             If ``True``, execution errors are ignored and the execution


### PR DESCRIPTION
Prevent the following downstream error:

```
Warning, treated as error:
/Users/silvester/workspace/nbconvert/docs/source/config_options.rst:2194:more than one target found for 'any' cross-reference 'CellExecutionError': could be :py:class:`nbconvert.preprocessors.CellExecutionError` or :py:class:`nbclient.exceptions.CellExecutionError`
```