### PR TITLE
Suppress most warnings in tests

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -3,7 +3,7 @@ include MANIFEST.in
 include requirements.txt
 include requirements-dev.txt
 include *.md
-include tox.ini
+include pytest.ini
 include pyproject.toml
 include .pre-commit-config.yaml
 include nbclient/py.typed

--- a/nbclient/tests/test_util.py
+++ b/nbclient/tests/test_util.py
@@ -14,11 +14,15 @@ async def some_async_function():
 
 
 def test_nested_asyncio_with_existing_ioloop():
-    ioloop = asyncio.new_event_loop()
-    try:
-        asyncio.set_event_loop(ioloop)
+    async def _test():
         assert some_async_function() == 42
-        assert asyncio.get_event_loop() is ioloop
+        return asyncio.get_running_loop()
+
+    loop = asyncio.new_event_loop()
+    asyncio.set_event_loop(loop)
+    try:
+        event_loop = loop.run_until_complete(_test())
+        assert event_loop is loop
     finally:
         asyncio._set_running_loop(None)  # it seems nest_asyncio doesn't reset this
 

--- a/nbclient/util.py
+++ b/nbclient/util.py
@@ -39,16 +39,14 @@ def check_patch_tornado() -> None:
 
 def just_run(coro: Awaitable) -> Any:
     """Make the coroutine run, even if there is an event loop running (using nest_asyncio)"""
-    # original from vaex/asyncio.py
-    loop = asyncio._get_running_loop()
+    try:
+        loop = asyncio.get_running_loop()
+    except RuntimeError:
+        loop = None
     if loop is None:
         had_running_loop = False
-        try:
-            loop = asyncio.get_event_loop()
-        except RuntimeError:
-            # we can still get 'There is no current event loop in ...'
-            loop = asyncio.new_event_loop()
-            asyncio.set_event_loop(loop)
+        loop = asyncio.new_event_loop()
+        asyncio.set_event_loop(loop)
     else:
         had_running_loop = True
     if had_running_loop:

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,2 @@
+[pytest]
+asyncio_mode = auto


### PR DESCRIPTION
There is still one warning related to ZMQ, I think it should be fixed there.
Fixes #211.