### PR TITLE
Make sure kernel is cleaned up in case an error occurred while starting kernel client

### DIFF
--- a/nbclient/cli.py
+++ b/nbclient/cli.py
@@ -35,12 +35,12 @@ class NbClientApp(JupyterApp):
     An application used to execute notebook files (``*.ipynb``)
     """
 
-    version = __version__
+    version = Unicode(__version__)
     name = 'jupyter-execute'
     aliases = nbclient_aliases
     flags = nbclient_flags
 
-    description = Unicode("An application used to execute notebook files (*.ipynb)")
+    description = "An application used to execute notebook files (*.ipynb)"
     notebooks = List([], help="Path of notebooks to convert").tag(config=True)
     timeout: int = Integer(
         None,

--- a/nbclient/client.py
+++ b/nbclient/client.py
@@ -39,7 +39,7 @@ from .output_widget import OutputWidget
 from .util import ensure_async, run_hook, run_sync
 
 
-def timestamp(msg: t.Optional[Dict] = None) -> str:
+def timestamp(msg: t.Optional[t.Dict] = None) -> str:
     if msg and 'header' in msg:  # The test mocks don't provide a header, so tolerate that
         msg_header = msg['header']
         if 'date' in msg_header and isinstance(msg_header['date'], datetime.datetime):
@@ -288,7 +288,9 @@ class NotebookClient(LoggingConfigurable):
         """,
     ).tag(config=True)
 
-    kernel_manager_class: KernelManager = Type(config=True, help='The kernel manager class to use.')
+    kernel_manager_class = Type(
+        config=True, klass=KernelManager, help='The kernel manager class to use.'
+    )
 
     on_notebook_start: t.Optional[t.Callable] = Callable(
         default_value=None,
@@ -390,7 +392,7 @@ class NotebookClient(LoggingConfigurable):
 
         return AsyncKernelManager
 
-    _display_id_map: t.Dict[str, t.Dict] = Dict(
+    _display_id_map = Dict(
         help=dedent(
             """
               mapping of locations of outputs with a given display_id
@@ -423,7 +425,7 @@ class NotebookClient(LoggingConfigurable):
             """,
     ).tag(config=True)
 
-    resources: t.Dict = Dict(
+    resources = Dict(
         help=dedent(
             """
             Additional resources used in the conversion process. For example,
@@ -560,7 +562,7 @@ class NotebookClient(LoggingConfigurable):
         try:
             self.kc = self.km.client()
             await ensure_async(self.kc.start_channels())  # type:ignore[func-returns-value]
-            await ensure_async(self.kc.wait_for_ready(timeout=self.startup_timeout))
+            await ensure_async(self.kc.wait_for_ready(timeout=self.startup_timeout))  # type:ignore
         except Exception as e:
             self.log.error(
                 "Error occurred while starting new kernel client for kernel {}: {}".format(
@@ -851,7 +853,7 @@ class NotebookClient(LoggingConfigurable):
 
     async def _async_check_alive(self) -> None:
         assert self.kc is not None
-        if not await ensure_async(self.kc.is_alive()):
+        if not await ensure_async(self.kc.is_alive()):  # type:ignore
             self.log.error("Kernel died while waiting for execute reply.")
             raise DeadKernelError("Kernel died")
 

--- a/nbclient/client.py
+++ b/nbclient/client.py
@@ -557,11 +557,12 @@ class NotebookClient(LoggingConfigurable):
             Kernel client as created by the kernel manager ``km``.
         """
         assert self.km is not None
-        self.kc = self.km.client()
-        await ensure_async(self.kc.start_channels())  # type:ignore[func-returns-value]
         try:
+            self.kc = self.km.client()
+            await ensure_async(self.kc.start_channels())  # type:ignore[func-returns-value]
             await ensure_async(self.kc.wait_for_ready(timeout=self.startup_timeout))
-        except RuntimeError:
+        except Exception as e:
+            self.log.error("Error occurred while starting new kernel client: %s" % str(e))
             await self._async_cleanup_kernel()
             raise
         self.kc.allow_stdin = False

--- a/nbclient/client.py
+++ b/nbclient/client.py
@@ -562,7 +562,11 @@ class NotebookClient(LoggingConfigurable):
             await ensure_async(self.kc.start_channels())  # type:ignore[func-returns-value]
             await ensure_async(self.kc.wait_for_ready(timeout=self.startup_timeout))
         except Exception as e:
-            self.log.error("Error occurred while starting new kernel client: %s" % str(e))
+            self.log.error(
+                "Error occurred while starting new kernel client for kernel {}: {}".format(
+                    self.km.kernel_id, str(e)
+                )
+            )
             await self._async_cleanup_kernel()
             raise
         self.kc.allow_stdin = False

--- a/nbclient/tests/test_client.py
+++ b/nbclient/tests/test_client.py
@@ -15,7 +15,7 @@ from unittest.mock import MagicMock, Mock
 import nbformat
 import pytest
 import xmltodict
-from jupyter_client import KernelManager, KernelClient
+from jupyter_client import KernelClient, KernelManager
 from jupyter_client.kernelspec import KernelSpecManager
 from nbconvert.filters import strip_ansi
 from nbformat import NotebookNode

--- a/nbclient/tests/test_client.py
+++ b/nbclient/tests/test_client.py
@@ -211,7 +211,11 @@ def prepare_cell_mocks(*messages_input, reply_msg=None):
             cell_mock = NotebookNode(
                 source='"foo" = "bar"', metadata={}, cell_type='code', outputs=[]
             )
-            executor = NotebookClient({})  # type:ignore
+
+            class NotebookClientWithParentID(NotebookClient):
+                parent_id: str
+
+            executor = NotebookClientWithParentID({})  # type:ignore
             executor.nb = {'cells': [cell_mock]}  # type:ignore
 
             # self.kc.iopub_channel.get_msg => message_mock.side_effect[i]

--- a/nbclient/tests/test_client.py
+++ b/nbclient/tests/test_client.py
@@ -510,7 +510,14 @@ def test_start_new_kernel_history_file_setting():
 
 def test_start_new_kernel_client_cleans_up_kernel_on_failure():
     class FakeClient(KernelClient):
-        def start_channels(self, *args, **kwargs) -> None:
+        def start_channels(
+            self,
+            shell: bool = True,
+            iopub: bool = True,
+            stdin: bool = True,
+            hb: bool = True,
+            control: bool = True
+        ) -> None:
             raise Exception("Any error")
 
         def stop_channels(self) -> None:

--- a/nbclient/tests/test_client.py
+++ b/nbclient/tests/test_client.py
@@ -516,7 +516,7 @@ def test_start_new_kernel_client_cleans_up_kernel_on_failure():
             iopub: bool = True,
             stdin: bool = True,
             hb: bool = True,
-            control: bool = True
+            control: bool = True,
         ) -> None:
             raise Exception("Any error")
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 jupyter_client>=6.1.5
 nbformat>=5.0
 nest_asyncio
-traitlets>=5.0.0
+traitlets>=5.2.2


### PR DESCRIPTION
In case an error happens in `start_channels()`, the kernel is never cleaned up, leading to leaks. For e.g., in `GatewayKernelClient` there is a chance we get `ConnectionError`.

Another place to ensure cleanup is in `setup_kernel`, however, since `async_start_new_kernel_client` already performs cleanup in case of timeout, I think it's a better fit here.

Added test to cover this. All tests passed locally.