### PR TITLE
Prevent file descriptor leak in util.just_run

### DIFF
--- a/nbclient/tests/test_util.py
+++ b/nbclient/tests/test_util.py
@@ -82,12 +82,9 @@ async def test_run_hook_async():
 def test_just_run_doesnt_leak_fds():
     proc = psutil.Process()
 
-    async def async_sleep():
-        await asyncio.sleep(0.01)
-
     # Warmup, just to make sure we're not failing on some initial fds being opened for the first time.
     for _ in range(10):
-        just_run(async_sleep())
+        just_run(asyncio.sleep(0.01))
     fds_count = proc.num_fds()
 
     diff = []

--- a/nbclient/tests/test_util.py
+++ b/nbclient/tests/test_util.py
@@ -92,7 +92,7 @@ def test_just_run_doesnt_leak_fds():
 
     diff = []
     for _ in range(10):
-        just_run(async_sleep())
+        just_run(asyncio.sleep(0.01))
         diff.append(proc.num_fds() - fds_count)
     assert diff == [0] * 10
 

--- a/nbclient/tests/test_util.py
+++ b/nbclient/tests/test_util.py
@@ -2,7 +2,7 @@ import asyncio
 import unittest.mock
 from unittest.mock import MagicMock
 
-import psutil
+import psutil  # type: ignore
 import pytest
 import tornado
 
@@ -95,15 +95,9 @@ def test_just_run_doesnt_leak_fds():
 
 
 def test_just_run_clears_new_loop():
-    async def async_sleep():
-        await asyncio.sleep(0.1)
-
     loop = asyncio.new_event_loop()
-    loop.stop = MagicMock(wraps=loop.stop)
-    loop.close = MagicMock(wraps=loop.close)
 
     with unittest.mock.patch.object(asyncio, "new_event_loop", return_value=loop):
-        just_run(async_sleep())
+        just_run(asyncio.sleep(0.01))
 
-    loop.stop.assert_called_once
-    loop.close.assert_called_once
+    assert loop.is_closed()

--- a/nbclient/util.py
+++ b/nbclient/util.py
@@ -57,7 +57,11 @@ def just_run(coro: Awaitable) -> Any:
 
         nest_asyncio.apply()
         check_patch_tornado()
-    return loop.run_until_complete(coro)
+    res = loop.run_until_complete(coro)
+    if not had_running_loop:
+        loop.stop()
+        loop.close()
+    return res
 
 
 T = TypeVar("T")

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -7,6 +7,7 @@ ipywidgets<8.0.0
 mypy
 pip>=18.1
 pre-commit
+psutil
 pytest>=4.1
 pytest-asyncio
 pytest-cov>=2.6.1


### PR DESCRIPTION
While working with [papermill](https://papermill.readthedocs.io/en/latest/) I've found that repeated running of notebooks is eventually bumping into the limit of number of opened files.

Following he stacktrace led me to `util.just_run` function that creates asyncio loop in some cases, but doesn't close them, which leaves some `eventpoll` file descriptors opened forever.

This PR consists of two commits
- The first commit creates a failing test, showing that the current implementation is leaving file descriptors opened after each run. On my machine (unix selectors), it leaves 3 FDs per `just_run` call. It also explicitly declares `psutil` as a dependency. It was already a transitive dependency, but I'm promoting to be explicit since I'm calling it directly.
- The second commit fixes the issue by stopping and closing used loop, but just in cases where the method created the loop.

Happy to discuss the approach, missing context, and next steps to fix this bug.