### PR TITLE
Fix tests for ipywidgets 8

### DIFF
--- a/nbclient/tests/files/JupyterWidgets.ipynb
+++ b/nbclient/tests/files/JupyterWidgets.ipynb
@@ -23,7 +23,7 @@
    "source": [
     "import ipywidgets\n",
     "label = ipywidgets.Label('Hello World')\n",
-    "label"
+    "display(label)"
    ]
   },
   {

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -5,6 +5,7 @@ ipykernel
 ipython
 ipywidgets
 mypy
+nbconvert
 pip>=18.1
 pre-commit
 pytest>=4.1

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -2,8 +2,8 @@ black
 check-manifest
 flake8
 ipykernel
-ipython<8.0.0
-ipywidgets<8.0.0
+ipython
+ipywidgets
 mypy
 pip>=18.1
 pre-commit


### PR DESCRIPTION
I believe that there is no reason to not use the latest versions of ipython and ipywidgets. Will see what CI thinks about it.