### PR TITLE
Don't use nest-asyncio

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
 jupyter_client>=6.1.5
 nbformat>=5.0
-nest_asyncio
 traitlets>=5.2.2


### PR DESCRIPTION
Instead of using `nest-asyncio`, use something similar to @maartenbreddels's [with_event_loop](https://github.com/vaexio/vaex/blob/633970528cb5091ef376dbca2e4721cd42525419/packages/vaex-core/vaex/asyncio.py#L6-L19).