### PR TITLE
Fix tests compatibility with IPython 8.5.0

### DIFF
--- a/nbclient/tests/test_client.py
+++ b/nbclient/tests/test_client.py
@@ -34,7 +34,7 @@ ipython_input_pat = re.compile(
 # Tracebacks look different in IPython 8,
 # see: https://github.com/ipython/ipython/blob/master/docs/source/whatsnew/version8.rst#traceback-improvements  # noqa
 ipython8_input_pat = re.compile(
-    r'(Input In \[\d+\]|<IPY-INPUT>), in (<module>|<cell line: \d>\(\))'
+    r'((Cell|Input) In \[\d+\]|<IPY-INPUT>), (in )?(line \d|<module>|<cell line: \d>\(\))'
 )
 
 hook_methods = [


### PR DESCRIPTION
The output has been changed again in IPython 8.5.0 https://github.com/ipython/ipython/blob/main/docs/source/whatsnew/version8.rst#restore-line-numbers-for-input