### PR TITLE
Handle client 8 support

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -57,6 +57,13 @@ jobs:
         args="-vv --maxfail=2 --cov=nbclient --cov-report=xml -W always"
         pytest $args || pytest $arg --lf
 
+    - name: Run the tests against client 8
+      shell: bash
+      run: |
+        pip install jupyter_client@https://github.com/blink1073/jupyter_client/archive/refs/heads/synchronous_managers.zip
+        args="-vv --maxfail=2 --cov=nbclient --cov-report=xml -W always"
+        pytest $args || pytest $arg --lf
+
     - name: Upload coverage to Codecov
       uses: codecov/codecov-action@v2
       with:

--- a/nbclient/client.py
+++ b/nbclient/client.py
@@ -491,12 +491,6 @@ class NotebookClient(LoggingConfigurable):
         else:
             self.km = self.kernel_manager_class(kernel_name=self.kernel_name, config=self.config)
         assert self.km is not None
-
-        # If the current kernel manager is still using the default (synchronous) KernelClient class,
-        # switch to the async version since that's what NBClient prefers.
-        if self.km.client_class == 'jupyter_client.client.KernelClient':
-            self.km.client_class = 'jupyter_client.asynchronous.AsyncKernelClient'
-
         return self.km
 
     async def _async_cleanup_kernel(self) -> None:

--- a/nbclient/tests/test_client.py
+++ b/nbclient/tests/test_client.py
@@ -641,6 +641,7 @@ while True: continue
         nb = executor.execute()
         assert 'language_info' in nb.metadata
         with executor.setup_kernel():
+            assert executor.kc is not None
             info_msg = executor.wait_for_reply(executor.kc.kernel_info())
             assert 'name' in info_msg["content"]["language_info"]
 

--- a/nbclient/tests/test_client.py
+++ b/nbclient/tests/test_client.py
@@ -653,9 +653,10 @@ while True: continue
             return False
 
         km.is_alive = is_alive
-        # Will be a RuntimeError or subclass DeadKernelError depending
+        # Will be a RuntimeError, TimeoutError, or subclass DeadKernelError
+        # depending
         # on if jupyter_client or nbconvert catches the dead client first
-        with pytest.raises(RuntimeError):
+        with pytest.raises((RuntimeError, TimeoutError)):
             input_nb, output_nb = executor.execute()
 
     def test_kernel_death_during_execution(self):

--- a/nbclient/tests/test_client.py
+++ b/nbclient/tests/test_client.py
@@ -643,6 +643,7 @@ while True: continue
         with executor.setup_kernel():
             assert executor.kc is not None
             info_msg = executor.wait_for_reply(executor.kc.kernel_info())
+            assert info_msg is not None
             assert 'name' in info_msg["content"]["language_info"]
 
     def test_kernel_death_after_timeout(self):

--- a/nbclient/tests/test_client.py
+++ b/nbclient/tests/test_client.py
@@ -635,6 +635,15 @@ while True: continue
         with pytest.raises(TimeoutError):
             run_notebook(filename, dict(timeout_func=timeout_func), res)
 
+    def test_sync_kernel_manager(self):
+        nb = nbformat.v4.new_notebook()  # Certainly has no language_info.
+        executor = NotebookClient(nb, kernel_name="python", kernel_manager_class=KernelManager)
+        nb = executor.execute()
+        assert 'language_info' in nb.metadata
+        with executor.setup_kernel():
+            info_msg = executor.wait_for_reply(executor.kc.kernel_info())
+            assert 'name' in info_msg["content"]["language_info"]
+
     def test_kernel_death_after_timeout(self):
         """Check that an error is raised when the kernel is_alive is false after a cell timed out"""
         filename = os.path.join(current_dir, 'files', 'Interrupt.ipynb')


### PR DESCRIPTION
Testing against https://github.com/jupyter/jupyter_client/pull/835 (as well as client 7 to double-check).  Adds support for using synchronous clients since nbconvert will need it going forward.