### PR TITLE
Remove nest-asyncio

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -42,7 +42,7 @@ repos:
     rev: v0.990
     hooks:
       - id: mypy
-        additional_dependencies: [jupyter_client, jupyter_core, nbformat, nbconvert]
+        additional_dependencies: [jupyter_client, jupyter_core>=5.1, nbformat, nbconvert]
 
   - repo: https://github.com/abravalheri/validate-pyproject
     rev: v0.10.1

--- a/binder/environment.yml
+++ b/binder/environment.yml
@@ -5,6 +5,6 @@ dependencies:
   - numpy
   - pandas
   - matplotlib
-  - nteract-scrapbook
+  - scrapbook
   - nbformat
   - nbclient

--- a/nbclient/tests/test_client.py
+++ b/nbclient/tests/test_client.py
@@ -35,7 +35,7 @@ ipython_input_pat = re.compile(
 # Tracebacks look different in IPython 8,
 # see: https://github.com/ipython/ipython/blob/master/docs/source/whatsnew/version8.rst#traceback-improvements  # noqa
 ipython8_input_pat = re.compile(
-    r'((Cell|Input) In \[\d+\]|<IPY-INPUT>), (in )?(line \d|<module>|<cell line: \d>\(\))'
+    r'((Cell|Input) In\[\d+\]|<IPY-INPUT>), (in )?(line \d|<module>|<cell line: \d>\(\))'
 )
 
 

--- a/nbclient/tests/test_util.py
+++ b/nbclient/tests/test_util.py
@@ -20,31 +20,23 @@ def test_nested_asyncio_with_existing_ioloop():
 
     loop = asyncio.new_event_loop()
     asyncio.set_event_loop(loop)
-    try:
-        event_loop = loop.run_until_complete(_test())
-        assert event_loop is loop
-    finally:
-        asyncio._set_running_loop(None)  # it seems nest_asyncio doesn't reset this
+    event_loop = loop.run_until_complete(_test())
+    assert event_loop is loop
 
 
 def test_nested_asyncio_with_no_ioloop():
     asyncio.set_event_loop(None)
-    try:
-        assert some_async_function() == 42
-    finally:
-        asyncio._set_running_loop(None)  # it seems nest_asyncio doesn't reset this
+    assert some_async_function() == 42
 
 
 def test_nested_asyncio_with_tornado():
     # This tests if tornado accepts the pure-Python Futures, see
     # https://github.com/tornadoweb/tornado/issues/2753
-    # https://github.com/erdewit/nest_asyncio/issues/23
     asyncio.set_event_loop(asyncio.new_event_loop())
     ioloop = tornado.ioloop.IOLoop.current()
 
     async def some_async_function():
         future: asyncio.Future = asyncio.ensure_future(asyncio.sleep(0.1))
-        # this future is a different future after nested-asyncio has patched
         # the asyncio module, check if tornado likes it:
         ioloop.add_future(future, lambda f: f.result())  # type:ignore
         await future
@@ -56,8 +48,6 @@ def test_nested_asyncio_with_tornado():
     async def run():
         # calling some_async_function directly should work
         assert await some_async_function() == 42
-        # but via a sync function (using nested-asyncio) can lead to issues:
-        # https://github.com/tornadoweb/tornado/issues/2753
         assert some_sync_function() == 42
 
     ioloop.run_sync(run)

--- a/nbclient/tests/test_util.py
+++ b/nbclient/tests/test_util.py
@@ -33,12 +33,12 @@ def test_nested_asyncio_with_tornado():
     # This tests if tornado accepts the pure-Python Futures, see
     # https://github.com/tornadoweb/tornado/issues/2753
     asyncio.set_event_loop(asyncio.new_event_loop())
-    ioloop = tornado.ioloop.IOLoop.current()
+    ioloop = tornado.ioloop.IOLoop.current()  # type: ignore
 
     async def some_async_function():
         future: asyncio.Future = asyncio.ensure_future(asyncio.sleep(0.1))
         # the asyncio module, check if tornado likes it:
-        ioloop.add_future(future, lambda f: f.result())  # type:ignore
+        ioloop.add_future(future, lambda f: f.result())
         await future
         return 42
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,9 +35,9 @@ classifiers = [
     "Programming Language :: Python :: 3.10",
 ]
 dependencies = [
-    "jupyter_client>=6.1.12",
-    "nbformat>=5.1",
-    "traitlets>=5.3",
+    "jupyter_client>=6.1.12,<8",
+    "nbformat>=5.1,<6",
+    "traitlets>=5.3<6",
 ]
 
 [project.optional-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,9 +35,9 @@ classifiers = [
     "Programming Language :: Python :: 3.10",
 ]
 dependencies = [
-    "jupyter_client>=6.1.12,<8",
-    "nbformat>=5.1,<6",
-    "traitlets>=5.3<6",
+    "jupyter_client>=6.1.12",
+    "nbformat>=5.1",
+    "traitlets>=5.3",
 ]
 
 [project.optional-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,7 +37,6 @@ classifiers = [
 dependencies = [
     "jupyter_client>=6.1.12",
     "nbformat>=5.1",
-    "nest_asyncio",
     "traitlets>=5.3",
 ]
 
@@ -153,7 +152,6 @@ warn_unused_ignores = true
 [[tool.mypy.overrides]]
 module = [
     "async_generator.*",
-    "nest_asyncio.*",
     "testpath",
     "xmltodict",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,7 +36,7 @@ classifiers = [
 ]
 dependencies = [
     "jupyter_client>=6.1.12",
-    "jupyter_core>=4.12",
+    "jupyter_core>=4.12,!=~5.0",
     "nbformat>=5.1",
     "traitlets>=5.3",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,6 +36,7 @@ classifiers = [
 ]
 dependencies = [
     "jupyter_client>=6.1.12",
+    "jupyter_core>=4.12",
     "nbformat>=5.1",
     "traitlets>=5.3",
 ]


### PR DESCRIPTION
Experimenting with jupyter-client's [run_sync](https://github.com/jupyter/jupyter_client/blob/76a0f575d1e47b28f017a909df9c5b696a8207e8/jupyter_client/utils.py#L51) which doesn't use `nest-asyncio`.