### PR TITLE
Fix test stability

### DIFF
--- a/nbclient/client.py
+++ b/nbclient/client.py
@@ -551,7 +551,7 @@ class NotebookClient(LoggingConfigurable):
         except Exception as e:
             self.log.error(
                 "Error occurred while starting new kernel client for kernel {}: {}".format(
-                    self.km.kernel_id, str(e)
+                    getattr(self.km, 'kernel_id', None), str(e)
                 )
             )
             await self._async_cleanup_kernel()

--- a/nbclient/tests/test_client.py
+++ b/nbclient/tests/test_client.py
@@ -15,6 +15,7 @@ from unittest.mock import MagicMock, Mock
 import nbformat
 import pytest
 import xmltodict
+from flaky import flaky
 from jupyter_client import KernelClient, KernelManager
 from jupyter_client._version import version_info
 from jupyter_client.kernelspec import KernelSpecManager
@@ -660,6 +661,7 @@ while True: continue
             assert info_msg is not None
             assert 'name' in info_msg["content"]["language_info"]
 
+    @flaky
     def test_kernel_death_after_timeout(self):
         """Check that an error is raised when the kernel is_alive is false after a cell timed out"""
         filename = os.path.join(current_dir, 'files', 'Interrupt.ipynb')

--- a/nbclient/tests/test_client.py
+++ b/nbclient/tests/test_client.py
@@ -15,7 +15,7 @@ from unittest.mock import MagicMock, Mock
 import nbformat
 import pytest
 import xmltodict
-from flaky import flaky
+from flaky import flaky  # type:ignore
 from jupyter_client import KernelClient, KernelManager
 from jupyter_client._version import version_info
 from jupyter_client.kernelspec import KernelSpecManager

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,6 +44,7 @@ dependencies = [
 
 [project.optional-dependencies]
 test = [
+    "flaky",
     "ipykernel",
     "ipython",
     "ipywidgets",


### PR DESCRIPTION
- Do not assume `km.kernel_id` is available in error report. 
- Add `flaky` for flaky test.