### PR TITLE
Increase timeout of test_run_all_notebooks[Interrupt.ipynb-opts6]

### DIFF
--- a/nbclient/tests/test_client.py
+++ b/nbclient/tests/test_client.py
@@ -323,7 +323,7 @@ def filter_messages_on_error_output(err_output):
             "Interrupt.ipynb",
             {
                 "kernel_name": "python",
-                "timeout": 1,
+                "timeout": 3,
                 "interrupt_on_timeout": True,
                 "allow_errors": True,
             },


### PR DESCRIPTION
This test is failing on riscv64 linux boards because
the interrupt happens too soon. Build log:
https://archriscv.felixc.at/.status/log.htm?url=logs/jupyter-nbclient/jupyter-nbclient-0.7.3-1.log