### PR TITLE
Bump min version support

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -40,7 +40,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: [ '3.7', '3.8', '3.9', '3.10', "3.11" ]
+        python-version: [ '3.8', '3.9', '3.10', "3.11" ]
         exclude:
           - os: windows-latest
             python-version: 3.8

--- a/nbclient/tests/files/Other Comms.ipynb
+++ b/nbclient/tests/files/Other Comms.ipynb
@@ -11,7 +11,7 @@
    },
    "outputs": [],
    "source": [
-    "from ipykernel.comm import Comm"
+    "from comm import create_comm"
    ]
   },
   {
@@ -25,7 +25,7 @@
    },
    "outputs": [],
    "source": [
-    "comm = Comm('this-comm-tests-a-missing-handler', data={'id': 'foo'})"
+    "comm = create_comm('this-comm-tests-a-missing-handler', data={'id': 'foo'})"
    ]
   },
   {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,7 +38,7 @@ dependencies = [
     "jupyter_client>=6.1.12",
     "jupyter_core>=4.12,!=5.0.*",
     "nbformat>=5.1",
-    "traitlets>=5.3",
+    "traitlets>=5.4",
 ]
 
 [project.optional-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,7 +45,7 @@ dependencies = [
 [project.optional-dependencies]
 test = [
     "flaky",
-    "ipykernel",
+    "ipykernel>=6.19.3",
     "ipython",
     "ipywidgets",
     "nbconvert>=7.0.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ dynamic = [
 description = "A client library for executing notebooks. Formerly nbconvert's ExecutePreprocessor."
 readme = "README.md"
 license = { file = "LICENSE" }
-requires-python = ">=3.7.0"
+requires-python = ">=3.8.0"
 authors = [
     { name = "Jupyter Development Team", email = "jupyter@googlegroups.com" },
 ]
@@ -29,7 +29,6 @@ classifiers = [
     "License :: OSI Approved :: BSD License",
     "Programming Language :: Python",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.7",
     "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",


### PR DESCRIPTION
Drop support for Python 3.7 and bump min version support.
Also update example notebook to use new `comm` package.

Fixes failing test:

```python
>           assert normalized_expected_outputs == normalized_actual_outputs
E           assert [] == [{'output_type': 'stream', 'name': 'stderr', 'text': "<IPY-INPUT>:1: DeprecationWarning: The `ipykernel.comm.Comm` class has been deprecated. Please use the `comm` module instead.For creating comms, use the function `from comm import create_comm`.\n  comm = Comm('this-comm-tests-a-missing-handler', data={'id': 'foo'})\n"}]
E             Right contains one more item: {'name': 'stderr', 'output_type': 'stream', 'text': "<IPY-INPUT>:1: DeprecationWarning: The `ipykernel.comm.Comm` clas...he function `from comm import create_comm`.\n  comm = Comm('this-comm-tests-a-missing-handler', data={'id': 'foo'})\n"}
E             Full diff:
E               [
E             +  ,
E             -  {'name': 'stderr',
E             -   'output_type': 'stream',
E             -   'text': '<IPY-INPUT>:1: DeprecationWarning: The `ipykernel.comm.Comm` class '
E             -           'has been deprecated. Please use the `comm` module instead.For '
E             -           'creating comms, use the function `from comm import create_comm`.\n'
E             -           "  comm = Comm('this-comm-tests-a-missing-handler', data={'id': "
E             -           "'foo'})\n"},
E               ]

nbclient/tests/test_client.py:289: AssertionError
```