### PR TITLE
Avoid a DeprecationWarning on Python 3.13+

### DIFF
--- a/nbclient/jsonutil.py
+++ b/nbclient/jsonutil.py
@@ -26,7 +26,7 @@ ISO8601_PAT = re.compile(
 
 # holy crap, strptime is not threadsafe.
 # Calling it once at import seems to help.
-datetime.strptime("1", "%d")
+datetime.strptime("2000-01-01", "%Y-%m-%d")
 
 # -----------------------------------------------------------------------------
 # Classes and functions


### PR DESCRIPTION
    ...
    /usr/lib/python3.13/site-packages/nbclient/jsonutil.py:29: in <module>
        datetime.strptime("1", "%d")
    /usr/lib64/python3.13/_strptime.py:573: in _strptime_datetime
        tt, fraction, gmtoff_fraction = _strptime(data_string, format)
    /usr/lib64/python3.13/_strptime.py:336: in _strptime
        format_regex = _TimeRE_cache.compile(format)
    /usr/lib64/python3.13/_strptime.py:282: in compile
        return re_compile(self.pattern(format), IGNORECASE)
    /usr/lib64/python3.13/_strptime.py:270: in pattern
        warnings.warn("""\
    E   DeprecationWarning: Parsing dates involving a day of month without a year specified is ambiguious
    E   and fails to parse leap day. The default behavior will change in Python 3.15
    E   to either always raise an exception or to use a different default year (TBD).
    E   To avoid trouble, add a specific year to the input & format.
    E   See https://github.com/python/cpython/issues/70647.

See also https://github.com/jupyter/jupyter_client/issues/1020