### PR TITLE
#329 add on cell input request

### DIFF
--- a/nbclient/client.py
+++ b/nbclient/client.py
@@ -331,7 +331,7 @@ class NotebookClient(LoggingConfigurable):
         help=dedent(
             """
             A callable which executes when a cell requests input.
-            Called with kwargs ``cell`` and ``cell_index``.
+            Called with kwargs ``cell``, ``cell_index``, and ``input_request``.
             """
         ),
     )
@@ -786,7 +786,7 @@ class NotebookClient(LoggingConfigurable):
                 if msg["parent_header"].get("msg_id") == parent_msg_id:
                     if msg["header"]["msg_type"] == "input_request":
                         response = await ensure_async(
-                            self.on_cell_input_request(cell=cell, cell_index=cell_index)
+                            self.on_cell_input_request(cell=cell, cell_index=cell_index, input_request=msg)
                         )
                         self.kc.input(response)
             except Empty:

--- a/tests/files/InputRequest.ipynb
+++ b/tests/files/InputRequest.ipynb
@@ -1,0 +1,21 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "name = input(\"What is your name? \")\n",
+    "print(f\"Hello, {name}!\")"
+   ]
+  }
+ ],
+ "metadata": {
+  "language_info": {
+   "name": "python"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 0
+}

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1001,6 +1001,7 @@ while True: continue
         call_args = hooks["on_cell_input_request"].call_args
         assert call_args[1]["cell"] == input_nb.cells[0]  # cell argument
         assert call_args[1]["cell_index"] == 0  # cell_index argument
+        assert "input_request" in call_args[1]  # input_request argument
 
 
 class TestRunCell(NBClientTestsBase):

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -57,6 +57,7 @@ hook_methods = [
     "on_cell_complete",
     "on_cell_executed",
     "on_cell_error",
+    "on_cell_input_request",
     "on_notebook_start",
     "on_notebook_complete",
     "on_notebook_error",
@@ -238,8 +239,10 @@ def prepare_cell_mocks(*messages_input, reply_msg=None):
             executor.kc = MagicMock(
                 iopub_channel=MagicMock(get_msg=message_mock),
                 shell_channel=MagicMock(get_msg=shell_channel_message_mock()),
+                stdin_channel=MagicMock(get_msg=AsyncMock(side_effect=Empty())),
                 execute=MagicMock(return_value=parent_id),
                 is_alive=MagicMock(return_value=make_future(True)),
+                input=MagicMock(),
             )
             executor.parent_id = parent_id
             return func(self, executor, cell_mock, message_mock)
@@ -901,6 +904,7 @@ while True: continue
         hooks["on_cell_complete"].assert_called_once()
         hooks["on_cell_executed"].assert_called_once()
         hooks["on_cell_error"].assert_not_called()
+        hooks["on_cell_input_request"].assert_not_called()
         hooks["on_notebook_start"].assert_called_once()
         hooks["on_notebook_complete"].assert_called_once()
         hooks["on_notebook_error"].assert_not_called()
@@ -917,6 +921,7 @@ while True: continue
         hooks["on_cell_complete"].assert_called_once()
         hooks["on_cell_executed"].assert_called_once()
         hooks["on_cell_error"].assert_called_once()
+        hooks["on_cell_input_request"].assert_not_called()
         hooks["on_notebook_start"].assert_called_once()
         hooks["on_notebook_complete"].assert_called_once()
         hooks["on_notebook_error"].assert_not_called()
@@ -933,6 +938,7 @@ while True: continue
         hooks["on_cell_complete"].assert_called_once()
         hooks["on_cell_executed"].assert_not_called()
         hooks["on_cell_error"].assert_not_called()
+        hooks["on_cell_input_request"].assert_not_called()
         hooks["on_notebook_start"].assert_called_once()
         hooks["on_notebook_complete"].assert_called_once()
         hooks["on_notebook_error"].assert_called_once()
@@ -948,6 +954,7 @@ while True: continue
         hooks["on_cell_complete"].assert_called_once()
         hooks["on_cell_executed"].assert_called_once()
         hooks["on_cell_error"].assert_not_called()
+        hooks["on_cell_input_request"].assert_not_called()
         hooks["on_notebook_start"].assert_called_once()
         hooks["on_notebook_complete"].assert_called_once()
         hooks["on_notebook_error"].assert_not_called()
@@ -964,9 +971,36 @@ while True: continue
         hooks["on_cell_complete"].assert_called_once()
         hooks["on_cell_executed"].assert_called_once()
         hooks["on_cell_error"].assert_called_once()
+        hooks["on_cell_input_request"].assert_not_called()
         hooks["on_notebook_start"].assert_called_once()
         hooks["on_notebook_complete"].assert_called_once()
         hooks["on_notebook_error"].assert_not_called()
+
+    def test_input_request_hook(self):
+        """Test that on_cell_input_request hook is called when cell requests input"""
+        filename = os.path.join(current_dir, "files", "InputRequest.ipynb")
+        with open(filename) as f:
+            input_nb = nbformat.read(f, 4)
+        executor, hooks = get_executor_with_hooks(nb=input_nb)
+
+        # Set up the input request hook to return a mock response
+        hooks["on_cell_input_request"].return_value = "Test User"
+
+        executor.execute()
+        hooks["on_cell_start"].assert_called_once()
+        hooks["on_cell_execute"].assert_called_once()
+        hooks["on_cell_complete"].assert_called_once()
+        hooks["on_cell_executed"].assert_called_once()
+        hooks["on_cell_error"].assert_not_called()
+        hooks["on_cell_input_request"].assert_called_once()
+        hooks["on_notebook_start"].assert_called_once()
+        hooks["on_notebook_complete"].assert_called_once()
+        hooks["on_notebook_error"].assert_not_called()
+
+        # Verify the callback was called with correct arguments
+        call_args = hooks["on_cell_input_request"].call_args
+        assert call_args[1]["cell"] == input_nb.cells[0]  # cell argument
+        assert call_args[1]["cell_index"] == 0  # cell_index argument
 
 
 class TestRunCell(NBClientTestsBase):
@@ -1763,6 +1797,7 @@ class TestRunCell(NBClientTestsBase):
             cell=cell_mock, cell_index=0, execute_reply=EXECUTE_REPLY_OK
         )
         hooks["on_cell_error"].assert_not_called()
+        hooks["on_cell_input_request"].assert_not_called()
         hooks["on_notebook_start"].assert_not_called()
         hooks["on_notebook_complete"].assert_not_called()
         hooks["on_notebook_error"].assert_not_called()
@@ -1793,6 +1828,7 @@ class TestRunCell(NBClientTestsBase):
         hooks["on_cell_error"].assert_called_once_with(
             cell=cell_mock, cell_index=0, execute_reply=EXECUTE_REPLY_ERROR
         )
+        hooks["on_cell_input_request"].assert_not_called()
         hooks["on_notebook_start"].assert_not_called()
         hooks["on_notebook_complete"].assert_not_called()
         hooks["on_notebook_error"].assert_not_called()
@@ -1829,6 +1865,7 @@ class TestRunCell(NBClientTestsBase):
             cell=cell_mock, cell_index=0, execute_reply=EXECUTE_REPLY_OK
         )
         hooks["on_cell_error"].assert_not_called()
+        hooks["on_cell_input_request"].assert_not_called()
         hooks["on_notebook_start"].assert_not_called()
         hooks["on_notebook_complete"].assert_not_called()
         hooks["on_notebook_error"].assert_not_called()
@@ -1859,6 +1896,7 @@ class TestRunCell(NBClientTestsBase):
         hooks["on_cell_error"].assert_called_once_with(
             cell=cell_mock, cell_index=0, execute_reply=EXECUTE_REPLY_ERROR
         )
+        hooks["on_cell_input_request"].assert_not_called()
         hooks["on_notebook_start"].assert_not_called()
         hooks["on_notebook_complete"].assert_not_called()
         hooks["on_notebook_error"].assert_not_called()


### PR DESCRIPTION
This PR is in response to #329. It adds a handler which allows the user of the NotebookClient to respond to input requests. This feature is lacking in many tools that run Jupyter Notebooks via script. Hopefully this will help facilitate the functionality in other places. I personally plan to use this feature very soon from the repo directly and will upgrade to pip as soon as it is available.

The implementation was fairly straightforward, but slightly more complicated than the original issue to blend more seamlessly. There is now a new async polling task that watches for input requests and then hands them off to the handler. The handler receives `cell`, `cell_index`, and `input_request`. If the handler is not set, this task is never spawned and functionality remains as is.

Tests were also modified to ensure that this new functionality was covered. 

## Usage

```py
import nbformat
from nbclient import NotebookClient

# Create a notebook with an input cell
nb = nbformat.v4.new_notebook()

# Add a cell that requests user input
cell = nbformat.v4.new_code_cell(
    source='''
# This cell requests user input
name = input("Enter your name: ")
age = input("Enter your age: ")
print(f"Hello {name}, you are {age} years old!")
'''
)
nb.cells.append(cell)

def handle_input_request(cell, cell_index, input_request):
    """Provide predefined responses to input requests."""
    print(f"📝 Input request from cell {cell_index}, {cell}, {input_request}")
    return "Response"

# Create and configure the client
client = NotebookClient(
    nb=nb,
    timeout=10,
    on_cell_input_request=handle_input_request
)

# Execute the notebook
client.execute()
nbformat.write(nb, "output_notebook.ipynb")
```

## Detailed Changes

* Added a new `on_cell_input_request` hook to the `NotebookClient` class, allowing users to handle input requests during cell execution. The hook is called with arguments `cell`, `cell_index`, and `input_request`. (`nbclient/client.py`, [nbclient/client.pyR328-R338](diffhunk://#diff-e944ee0f8a9ca3477dcb8a54dab58de75437c6f6d503de0136fc729c0448b08dR328-R338))
* Updated the kernel client configuration to enable `allow_stdin` only if the `on_cell_input_request` hook is defined. (`nbclient/client.py`, [nbclient/client.pyL575-R586](diffhunk://#diff-e944ee0f8a9ca3477dcb8a54dab58de75437c6f6d503de0136fc729c0448b08dL575-R586))
* Implemented `_async_poll_stdin_msg`, an asynchronous method to handle input requests from the kernel by invoking the `on_cell_input_request` hook and sending the response back to the kernel. (`nbclient/client.py`, [nbclient/client.pyR772-R796](diffhunk://#diff-e944ee0f8a9ca3477dcb8a54dab58de75437c6f6d503de0136fc729c0448b08dR772-R796))
* Integrated the new input request handling into the `async_execute_cell` method, ensuring input polling tasks are created, managed, and properly canceled. (`nbclient/client.py`, Fae205e2L996R1050)
* Added a new test notebook (`InputRequest.ipynb`) containing a cell with an `input()` call to validate the input request functionality. (`tests/files/InputRequest.ipynb`, [tests/files/InputRequest.ipynbR1-R21](diffhunk://#diff-0da4fb5876832cede49ff537fa45b4c7e1a593db0424b849ccad9ee25c34bc3eR1-R21))
* Updated the test framework to include the `on_cell_input_request` hook and mock its behavior for various test cases. (`tests/test_client.py`, [[1]](diffhunk://#diff-0d92063e88430a02df61616c5f16b148b64ac4539d9cb9b8d883d5a23351b110R60) [[2]](diffhunk://#diff-0d92063e88430a02df61616c5f16b148b64ac4539d9cb9b8d883d5a23351b110R242-R245)
* Added a dedicated test (`test_input_request_hook`) to verify the `on_cell_input_request` hook is called correctly and with the expected arguments when a cell requests input. (`tests/test_client.py`, [tests/test_client.pyR974-R1005](diffhunk://#diff-0d92063e88430a02df61616c5f16b148b64ac4539d9cb9b8d883d5a23351b110R974-R1005))