### PR TITLE
drop leftover ref. to async_generator

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -173,7 +173,6 @@ warn_unreachable = true
 
 [[tool.mypy.overrides]]
 module = [
-    "async_generator.*",
     "testpath",
     "xmltodict",
 ]


### PR DESCRIPTION
we are trying to remove async_generator from Debian.

this came up while grepping

this is a follow up to https://github.com/jupyter/nbclient/pull/154 from 2021