### PR TITLE
Ignore new warning from ipykernel about encryption

### DIFF
--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -319,7 +319,6 @@ def filter_messages_on_error_output(err_output):
         for line in err_output.splitlines()
         if not any(line.startswith(prefix) for prefix in allowed_prefixes)
     ]
-    lines = err_output.splitlines()
     # Known benign race condition: kernel sends a status message on a socket already
     # closed during parallel shutdown. Filter the entire traceback block.
     in_zmq_traceback = False

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -308,11 +308,16 @@ def notebook_resources():
 
 
 def filter_messages_on_error_output(err_output):
-    allowed_lines = [
+    allowed_prefixes = [
         # ipykernel might be installed without debugpy extension
-        "[IPKernelApp] WARNING | debugpy_stream undefined, debugging will not be enabled",
+        "[IPKernelApp] WARNING | debugpy_stream undefined",
+        # ipykernel warns when kernel runs over TCP without CurveZMQ encryption
+        "[IPKernelApp] WARNING | Kernel is running over TCP without encryption.",
     ]
-    filtered_result = [line for line in err_output.splitlines() if line not in allowed_lines]
+    filtered_result = [
+        line for line in err_output.splitlines()
+        if not any(line.startswith(prefix) for prefix in allowed_prefixes)
+    ]
 
     return os.linesep.join(filtered_result)
 

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -323,18 +323,17 @@ def filter_messages_on_error_output(err_output):
     # Known benign race condition: kernel sends a status message on a socket already
     # closed during parallel shutdown. Filter the entire traceback block.
     in_zmq_traceback = False
-    filtered_result = []
-    for line in lines:
+    final_filtered_result = []
+    for line in filtered_result:
         if "ERROR:tornado.general:Uncaught exception in ZMQStream callback" in line:
             in_zmq_traceback = True
         if in_zmq_traceback:
             if "zmq.error.ZMQError: Socket operation on non-socket" in line:
                 in_zmq_traceback = False
             continue
-        if line not in allowed_lines:
-            filtered_result.append(line)
+        final_filtered_result.append(line)
 
-    return os.linesep.join(filtered_result)
+    return os.linesep.join(final_filtered_result)
 
 
 @pytest.mark.parametrize(

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -315,7 +315,8 @@ def filter_messages_on_error_output(err_output):
         "[IPKernelApp] WARNING | Kernel is running over TCP without encryption.",
     ]
     filtered_result = [
-        line for line in err_output.splitlines()
+        line
+        for line in err_output.splitlines()
         if not any(line.startswith(prefix) for prefix in allowed_prefixes)
     ]
 


### PR DESCRIPTION
use first-sentence prefix matching so that we can adjust the advice that follows in following sentences without updating downstream tests

References:
- https://github.com/ipython/ipykernel/pull/1515
- https://github.com/jupyter/jupyter_client/issues/808