### PR TITLE
Minor cleanup and bump minimal versions.

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -67,9 +67,9 @@ repos:
         additional_dependencies:
           [
             "traitlets>=5.13",
-            "jupyter_core>=5.3.2",
-            "jupyter_client",
-            "nbformat",
+            "jupyter_core>=5.4.0",
+            "jupyter_client>=7.0.0",
+            "nbformat>=5.2.0",
           ]
 
   - repo: https://github.com/astral-sh/ruff-pre-commit

--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
 [![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/jupyter/nbclient/main?filepath=binder%2Frun_nbclient.ipynb)
 [![Build Status](https://github.com/jupyter/nbclient/workflows/CI/badge.svg)](https://github.com/jupyter/nbclient/actions)
 [![Documentation Status](https://readthedocs.org/projects/nbclient/badge/?version=latest)](https://nbclient.readthedocs.io/en/latest/?badge=latest)
-[![Code style: black](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/ambv/black)
 
 # nbclient
 
@@ -31,7 +30,7 @@ See [ReadTheDocs](https://nbclient.readthedocs.io/en/latest/) for more in-depth 
 
 ## Python Version Support
 
-This library currently supports Python 3.6+ versions. As minor Python
+This library currently supports Python 3.10+ versions. As minor Python
 versions are officially sunset by the Python org, nbclient will similarly
 drop support in the future.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,17 +29,12 @@ classifiers = [
     "License :: OSI Approved :: BSD License",
     "Programming Language :: Python",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.10",
-    "Programming Language :: Python :: 3.11",
-    "Programming Language :: Python :: 3.12",
-    "Programming Language :: Python :: 3.13",
-    "Programming Language :: Python :: 3.14",
 ]
 dependencies = [
-    "jupyter_client>=6.1.12",
-    "jupyter_core>=4.12,!=5.0.*",
-    "nbformat>=5.1.3",
-    "traitlets>=5.4",
+    "jupyter_client>=7.0.0",
+    "jupyter_core>=5.4.0",
+    "nbformat>=5.2.0",
+    "traitlets>=5.13",
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
I think jupyter core >=5.3.2 was a mistake and *strictly* was meant maybe?

And update all other deps to ~2 years old versions.